### PR TITLE
New bdaq scripts for RD53A quad modules

### DIFF
--- a/bdaq_xray_scripts/step1_scan_digital.py
+++ b/bdaq_xray_scripts/step1_scan_digital.py
@@ -1,0 +1,83 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This basic scan injects a digital pulse into
+    enabled pixels to test the digital part of the chip.
+'''
+
+from tqdm import tqdm
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.chips.shift_and_inject import shift_and_inject_digital, get_scan_loop_mask_steps
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192
+}
+
+
+class DigitalScan(ScanBase):
+    scan_id = 'digital_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+        '''
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks.apply_disable_mask()
+
+#         self.chip.masks.load_logo_mask(['injection'])
+
+        self.chip.masks.update(force=True)
+
+        self.chip.setup_digital_injection()
+
+    def _scan(self, n_injections=100, **_):
+        '''
+        Digital scan main loop
+
+        Parameters
+        ----------
+        n_injections : int
+            Number of injections.
+        '''
+
+        pbar = tqdm(total=get_scan_loop_mask_steps(scan=self), unit=' Mask steps')
+        with self.readout(scan_param_id=0):
+            shift_and_inject_digital(scan=self, n_injections=n_injections, pbar=pbar, scan_param_id=0)
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+
+if __name__ == '__main__':
+    with DigitalScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step2_scan_analog_disable.py
+++ b/bdaq_xray_scripts/step2_scan_analog_disable.py
@@ -1,0 +1,58 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This basic scan injects a specified charge into
+    enabled pixels to test the analog front-end.
+    Pixel that do not exceed the minmal occupancy get masked.
+'''
+
+import tables as tb
+import numpy as np
+
+from bdaq53.analysis import analysis
+from bdaq53.scans.scan_analog import AnalogScan
+import bdaq53.analysis.analysis_utils as au
+
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    'VCAL_MED': 500,
+    'VCAL_HIGH': 1450,
+
+    'min_occupancy': 10
+}
+
+
+class AnalogDisableScan(AnalogScan):
+    scan_id = 'analog_scan'
+
+    def _analyze(self):
+        super(AnalogDisableScan, self)._analyze()
+
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5') as a:
+            with tb.open_file(a.analyzed_data_file) as in_file:
+
+                scan_config = au.ConfigDict(in_file.root.configuration_in.scan.scan_config[:])
+                min_occupancy = scan_config.get('min_occupancy', 1)
+
+                occupancy = in_file.root.HistOcc[:].sum(axis=2)
+                disable_mask = np.logical_or(occupancy > min_occupancy, np.logical_not(self.chip.masks['enable']))
+        n_disabled_pixels = np.count_nonzero(np.invert(disable_mask))
+
+        self.chip.masks.disable_mask = disable_mask
+        self.chip.masks.apply_disable_mask()
+        self.log.success('Found and disabled {0} dead pixels.'.format(n_disabled_pixels))
+
+
+if __name__ == '__main__':
+    with AnalogDisableScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step2b_scan_analog.py
+++ b/bdaq_xray_scripts/step2b_scan_analog.py
@@ -1,0 +1,95 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This basic scan injects a specified charge into
+    enabled pixels to test the analog front-end.
+'''
+
+from tqdm import tqdm
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.chips.shift_and_inject import shift_and_inject, get_scan_loop_mask_steps
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    'VCAL_MED': 500,
+    'VCAL_HIGH': 1450
+}
+
+
+class AnalogScan(ScanBase):
+    scan_id = 'analog_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, VCAL_MED=1000, VCAL_HIGH=4000, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+
+        VCAL_MED : int
+            VCAL_MED DAC value.
+        VCAL_HIGH : int
+            VCAL_HIGH DAC value.
+        '''
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks.apply_disable_mask()
+
+#         self.chip.masks.load_logo_mask(['injection'])
+
+        self.chip.masks.update(force=True)
+
+        self.chip.setup_analog_injection(vcal_high=VCAL_HIGH, vcal_med=VCAL_MED)
+
+    def _scan(self, n_injections=100, **_):
+        '''
+        Analog scan main loop
+
+        Parameters
+        ----------
+        n_injections : int
+            Number of injections.
+
+        VCAL_MED : int
+            VCAL_MED DAC value.
+        VCAL_HIGH_start : int
+            VCAL_HIGH DAC value.
+        '''
+        pbar = tqdm(total=get_scan_loop_mask_steps(scan=self), unit=' Mask steps')
+        with self.readout(scan_param_id=0):
+            shift_and_inject(scan=self, n_injections=n_injections, pbar=pbar, scan_param_id=0)
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+
+if __name__ == '__main__':
+    with AnalogScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step3_tune_global_threshold.py
+++ b/bdaq_xray_scripts/step3_tune_global_threshold.py
@@ -1,0 +1,281 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    Finds the optimum global threshold value for target threshold using binary search algorithm.
+    Online analysis is used to calculate hit occupancy in order to speed up the tuning.
+    Allows tuning of multiple RD53A flavours at the same time.
+'''
+
+import numpy as np
+from tqdm import tqdm
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.chips.shift_and_inject import shift_and_inject
+from bdaq53.analysis import online as oa
+
+np.warnings.filterwarnings('ignore')
+
+
+scan_configuration = {
+    # Run for only SYNC: columns from 0 to 128
+    'start_column': 0,
+    'stop_column': 128,
+    'start_row': 0,
+    'stop_row': 192,
+
+    'n_injections': 100,
+
+    # Target threshold
+    'VCAL_MED': 500,
+    'VCAL_HIGH': 723,
+
+    # This setting does not have to be changed, it only allows (slightly) faster retuning
+    # E.g.: gdac_value_bits = [3, 2, 1, 0] uses the 4th, 3rd, 2nd, and 1st GDAC value bit.
+    # GDAC is not an existing DAC, its value is mapped to the respective FE registers.
+    'gdac_value_bits': range(9, -1, -1)
+}
+
+
+class GDACTuning(ScanBase):
+    scan_id = 'global_threshold_tuning'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, VCAL_MED=1000, VCAL_HIGH=4000, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+
+        VCAL_MED : int
+            VCAL_MED DAC value.
+        VCAL_HIGH_start : int
+            VCAL_HIGH DAC value.
+        '''
+
+        self.data.start_column, self.data.stop_column, self.data.start_row, self.data.stop_row = start_column, stop_column, start_row, stop_row
+        self.data.flavors = []
+        if self.chip.chip_type.lower() == 'rd53a':
+            self.n_flavours = 3
+            if start_column < 128:
+                self.data.flavors.append('SYNC')
+            if start_column < 264 and stop_column > 128:
+                self.data.flavors.append('LIN')
+            if stop_column > 264:
+                self.data.flavors.append('DIFF')
+                left_border = 264
+        else:
+            self.n_flavours = 1
+            self.data.flavors.append('DIFF')
+            left_border = 0
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][start_column:stop_column, start_row:stop_row] = True
+
+        self.chip.masks.apply_disable_mask()
+
+        self.chip.masks.update(force=True)
+
+        # Global threshold scan should always be done with centered TDAC
+        if 'LIN' in self.data.flavors:
+            mean_tdac_lin = np.mean(self.chip.masks['tdac'][max(128, start_column):min(264, stop_column), start_row:stop_row])
+            if mean_tdac_lin < 6 or mean_tdac_lin > 8:
+                self.log.warning('Mean TDAC for LIN is {0:1.1f}. Global threhsold tuning should always be run with centered TDAC!'.format(mean_tdac_lin))
+        if 'DIFF' in self.data.flavors:
+            mean_tdac_diff = np.mean(self.chip.masks['tdac'][max(left_border, start_column):min(400, stop_column), start_row:stop_row])
+            if mean_tdac_diff < -3 or mean_tdac_diff > 3:
+                self.log.warning('Mean TDAC for DIFF is {0:1.1f}. Global threhsold tuning should always be run with centered TDAC!'.format(mean_tdac_diff))
+
+        self.chip.setup_analog_injection(vcal_high=VCAL_HIGH, vcal_med=VCAL_MED)
+
+        hmap_is_compressed = False if (self.chip_conf.get('CoreColEncoderConf', 0) & 0b01000000000) else True  # compression of hitmap word (in case of ITkPixV1)
+        self.data.hist_occ = oa.OccupancyHistogramming(chip_type=self.chip.chip_type.lower(), hmap_is_compressed=hmap_is_compressed, rx_id=int(self.chip.receiver[-1]))
+
+    def _scan(self, n_injections=100, gdac_value_bits=range(9, -1, -1), **_):
+        '''
+        Global threshold tuning main loop
+
+        Parameters
+        ----------
+        n_injections : int
+            Number of injections.
+        gdac_value_bits : iterable
+            Bits to toggle during tuning. Should be monotone.
+        '''
+
+        def update_best_gdacs(mean_occ, best_gdacs, best_gdac_offsets):
+            for i in range(self.n_flavours):  # loop flavors
+                if np.abs(mean_occ[i] - n_injections / 2.) < best_gdac_offsets[i]:
+                    best_gdac_offsets[i] = np.abs(mean_occ[i] - n_injections / 2.)
+                    best_gdacs[i] = gdac_new[i]
+            return best_gdacs, best_gdac_offsets
+
+        def write_gdac_registers(gdacs):
+            ''' Write new GDAC setting for enabled flavors '''
+            if 'SYNC' in self.data.flavors:
+                self.chip.registers['VTH_SYNC'].write(gdacs[0])
+                self.chip.configuration['registers']['VTH_SYNC'] = int(gdacs[0])
+            if 'LIN' in self.data.flavors:
+                self.chip.registers['Vthreshold_LIN'].write(gdacs[1])
+                self.chip.configuration['registers']['Vthreshold_LIN'] = int(gdacs[1])
+            if 'DIFF' in self.data.flavors:
+                if self.chip.chip_type.lower() == 'rd53a':
+                    self.chip.registers['VTH1_DIFF'].write(gdacs[2])
+                    self.chip.configuration['registers']['VTH1_DIFF'] = int(gdacs[2])
+                else:
+                    self.chip.registers['DAC_TH1_L_DIFF'].write(gdacs[0])
+                    self.chip.registers['DAC_TH1_R_DIFF'].write(gdacs[0])
+                    self.chip.registers['DAC_TH1_M_DIFF'].write(gdacs[0])
+                    self.chip.configuration['registers']['DAC_TH1_L_DIFF'] = int(gdacs[0])
+                    self.chip.configuration['registers']['DAC_TH1_R_DIFF'] = int(gdacs[0])
+                    self.chip.configuration['registers']['DAC_TH1_M_DIFF'] = int(gdacs[0])
+
+        # Set GDACs to start value
+        start_value = 2 ** gdac_value_bits[0]
+        # FIXME: keep track of chip config here, since it is not provided by bdaq53 yet?
+        gdac_new = [start_value] * self.n_flavours  # sync/linear/differential
+        best_gdacs = [start_value] * self.n_flavours
+
+        # Only check pixel that can respond
+        sel_pixel = self.chip.masks['enable'].copy()
+        sel_pixel[self.data.start_column:self.data.stop_column, self.data.start_row:self.data.stop_row] = True
+
+        self.log.info('Searching optimal global threshold setting for {0}.'.format(', '.join(self.data.flavors)))
+        self.data.pbar = tqdm(total=len(gdac_value_bits) * self.chip.masks.get_mask_steps() * 2, unit=' Mask steps')
+        for scan_param_id in range(len(gdac_value_bits)):
+            # Set the GDAC bit in all flavours
+            gdac_bit = gdac_value_bits[scan_param_id]
+            for i in range(self.n_flavours):
+                gdac_new[i] = np.bitwise_or(gdac_new[i], 1 << gdac_bit)
+            write_gdac_registers(gdac_new)
+
+            # Calculate new GDAC from hit occupancies: median pixel hits < n_injections / 2 --> decrease global threshold
+            hist_occ = self.get_occupancy(scan_param_id, n_injections)
+            if self.chip.chip_type.lower() == 'rd53a':
+                mean_occ = [np.median(hist_occ[:128][sel_pixel[:128]]),         # SYNC
+                            np.median(hist_occ[128:264][sel_pixel[128:264]]),   # LIN
+                            np.median(hist_occ[264:][sel_pixel[264:]])]         # DIFF
+            else:
+                mean_occ = [np.median(hist_occ[sel_pixel])]
+
+            self.log.info('Mean occ. is {0} at GDAC setting {1}'.format(mean_occ, gdac_new))
+
+            # Binary search does not have to converge to best solution for not exact matches
+            # Thus keep track of best solution and set at the end if needed
+            if not scan_param_id:  # First iteration --> initialize best gdac settings
+                if self.chip.chip_type.lower() == 'rd53a':
+                    best_gdac_offsets = [np.abs(mean_occ[0] - n_injections / 2.), np.abs(mean_occ[1] - n_injections / 2.), np.abs(mean_occ[2] - n_injections / 2.)]
+                else:
+                    best_gdac_offsets = [np.abs(mean_occ[0] - n_injections / 2.)]
+            else:  # Update better settings
+                best_gdacs, best_gdac_offsets = update_best_gdacs(mean_occ, best_gdacs, best_gdac_offsets)
+
+            # Seedup by skipping remaining iterations if result for all selected flavors is already found
+            if np.all((mean_occ == np.array([n_injections / 2.] * 3)) | np.isnan(mean_occ)):
+                self.log.info('Found best result, skip remaining iterations')
+                break
+
+            # Update GDACS from measured mean occupancy
+            for i in range(self.n_flavours):  # SYNC / LIN / DIFF
+                if not np.isnan(mean_occ[i]) and mean_occ[i] < n_injections / 2.:  # threshold too high
+                    gdac_new[i] = np.bitwise_and(gdac_new[i], ~(1 << gdac_bit))  # decrease threshold
+        else:  # Loop finished but last bit = 0 still has to be checked
+            self.data.pbar.close()
+            scan_param_id += 1
+            for i in range(self.n_flavours):
+                gdac_new[i] = np.bitwise_and(gdac_new[i], ~(1 << gdac_bit))
+            # Check if setting was already used before, safe time of one iteration
+            if best_gdacs != gdac_new:
+                write_gdac_registers(gdac_new)
+                hist_occ = self.get_occupancy(scan_param_id, n_injections)
+                if self.chip.chip_type.lower() == 'rd53a':
+                    mean_occ = [np.median(hist_occ[:128][sel_pixel[:128]]),         # SYNC
+                                np.median(hist_occ[128:264][sel_pixel[128:264]]),   # LIN
+                                np.median(hist_occ[264:][sel_pixel[264:]])]         # DIFF
+                else:
+                    mean_occ = [np.median(hist_occ[sel_pixel])]
+
+                self.log.info('Mean occ. is {0} at GDAC setting {1}'.format(mean_occ, gdac_new))
+
+                best_gdacs, best_gdac_offsets = update_best_gdacs(mean_occ, best_gdacs, best_gdac_offsets)
+        self.data.pbar.close()
+
+        if self.chip.chip_type.lower() == 'rd53a':
+            if 'SYNC' in self.data.flavors:
+                self.log.success('Optimal VTH_SYNC value is {0:1.0f}'.format(best_gdacs[0]))
+            if 'LIN' in self.data.flavors:
+                self.log.success('Optimal Vthreshold_LIN value is {0:1.0f}'.format(best_gdacs[1]))
+            if 'DIFF' in self.data.flavors:
+                self.log.success('Optimal VTH1_DIFF value is {0:1.0f}'.format(best_gdacs[2]))
+        else:
+            self.log.success('Optimal DAC_TH1_DIFF value is {0:1.0f}'.format(best_gdacs[0]))
+
+        # Set final result
+        self.data.best_gdacs = best_gdacs
+        write_gdac_registers(best_gdacs)
+
+        self.data.hist_occ.close()  # stop analysis process
+
+    def get_occupancy(self, scan_param_id, n_injections):
+        ''' Analog scan and stuck pixel scan '''
+
+        if self.chip.chip_type.lower() == 'rd53a':  # FIXME: makes ITkPixV1 stuck
+            self.chip.revive()
+
+        # Inject target charge
+        with self.readout(scan_param_id=scan_param_id, callback=self.analyze_data_online):
+            shift_and_inject(scan=self, n_injections=n_injections, pbar=self.data.pbar, scan_param_id=scan_param_id)
+
+        # Get hit occupancy using online analysis
+        occupancy = self.data.hist_occ.get()
+
+        # Revive chip
+        if self.chip.chip_type.lower() == 'rd53a':  # FIXME: makes ITkPixV1 stuck
+            self.chip.revive()
+
+        # Scan stuck pixels. TODO: check if this makes sense for ITkPixV1
+        if self.chip.chip_type.lower() == 'rd53a':
+            with self.readout(scan_param_id=scan_param_id, callback=self.analyze_data_online_no_save):
+                for fe, _ in self.chip.masks.shift(masks=['enable']):
+                    if not fe == 'skipped':
+                        self.chip.toggle_output_select(send_ecr=True if fe == 'SYNC' else False, repetitions=10)
+                    self.data.pbar.update(1)
+            stuck = self.data.hist_occ.get() > 0
+        else:
+            stuck = np.zeros_like(self.chip.masks['tdac'])
+        occupancy[stuck] = n_injections
+
+        return occupancy
+
+    def analyze_data_online(self, data_tuple, receiver=None):
+        raw_data = data_tuple[0]
+        if self.chip.chip_type.lower() == 'itkpixv1':  # ITkPixv1 needs ptot table for analysis
+            self.data.hist_occ.add(raw_data, self.ptot_table[:])
+        else:
+            self.data.hist_occ.add(raw_data)
+        super(GDACTuning, self).handle_data(data_tuple, receiver)
+
+    def analyze_data_online_no_save(self, data_tuple, receiver=None):
+        raw_data = data_tuple[0]
+        if self.chip.chip_type.lower() == 'itkpixv1':  # ITkPixv1 needs ptot table for analysis
+            self.data.hist_occ.add(raw_data, self.ptot_table[:])
+        else:
+            self.data.hist_occ.add(raw_data)
+
+    def _analyze(self):
+        pass
+
+
+if __name__ == '__main__':
+    with GDACTuning(scan_config=scan_configuration) as tuning:
+        tuning.start()

--- a/bdaq_xray_scripts/step4_meta_tune_threshold.py
+++ b/bdaq_xray_scripts/step4_meta_tune_threshold.py
@@ -1,0 +1,77 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    Tune global and local threshold and disable noisy and stuck pixels.
+    Run a threshold scan in the end to verify results.
+'''
+
+from bdaq53.scans.tune_global_threshold import GDACTuning
+from bdaq53.scans.tune_local_threshold import TDACTuning
+from bdaq53.scans.scan_noise_occupancy import NoiseOccScan
+from bdaq53.scans.scan_stuck_pixel import StuckPixelScan
+from bdaq53.scans.scan_threshold import ThresholdScan
+
+
+scan_configuration = {
+    # Run for only LIN and DIFF: columns from 128 to 400
+    'start_column': 128,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    # Target threshold
+    'VCAL_MED': 500,
+    'VCAL_HIGH': 723,
+}
+
+noise_occ_scan_configuration = {
+    # Start the scan with a fresh disable mask (resets pixels disabled by other scans)?
+    'reset_disable_mask': True,
+
+    # 'max_occupancy': 1e-6,  # Maximum noise occupancy per bunch crossing
+    'n_triggers': 1e7,      # Total number of triggers which are send
+    'min_occupancy': 10,    # All pixels with more hits than this threshold are masked as noisy
+    'certainty': 2.0,       # Expected/tolerable number of wrongly classified pixels (noisy vs. quiet). Note that amount of noise changes with time on a real chip.
+    'stop_timeout': 20,     # Scan stops if number of unclassified pixels did not change for stop_timeout seconds. Hard cut is applied to remaining pixels.
+    'max_scan_time': 120    # Maximum scan time to prevent not terminating scan. Hard cut is applied to remaining pixels.
+}
+
+
+if __name__ == '__main__':
+    noise_occ_scan_configuration['start_column'] = scan_configuration['start_column']
+    noise_occ_scan_configuration['stop_column'] = scan_configuration['stop_column']
+    noise_occ_scan_configuration['start_row'] = scan_configuration['start_row']
+    noise_occ_scan_configuration['stop_row'] = scan_configuration['stop_row']
+
+    with GDACTuning(scan_config=scan_configuration) as global_tuning:
+        global_tuning.start()
+
+    with TDACTuning(scan_config=scan_configuration) as local_tuning:
+        local_tuning.start()
+
+    # skip the rest!
+    ## First noise occupancy scan
+    #with NoiseOccScan(scan_config=noise_occ_scan_configuration) as noise_occ_scan:
+    #    noise_occ_scan.start()
+
+    #with StuckPixelScan(scan_config=scan_configuration) as stuck_pix_scan:
+    #    stuck_pix_scan.start()
+
+    ## Second noise occupancy scan, find more noisy pixels
+    #noise_occ_scan_configuration['reset_disable_mask'] = False
+    #with NoiseOccScan(scan_config=noise_occ_scan_configuration) as noise_occ_scan:
+    #    noise_occ_scan.start()
+
+    ## Calculate scan range for threshold scan
+    #target_threshold = scan_configuration['VCAL_HIGH'] - scan_configuration['VCAL_MED']
+    #scan_configuration['VCAL_HIGH_start'] = scan_configuration['VCAL_MED'] + target_threshold - 50
+    #scan_configuration['VCAL_HIGH_stop'] = scan_configuration['VCAL_MED'] + target_threshold + 50
+    #scan_configuration['VCAL_HIGH_step'] = 2
+    #with ThresholdScan(scan_config=scan_configuration) as thr_scan:
+    #    thr_scan.start()
+

--- a/bdaq_xray_scripts/step5_scan_noise_occupancy.py
+++ b/bdaq_xray_scripts/step5_scan_noise_occupancy.py
@@ -1,0 +1,138 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This basic scan sends triggers without injection
+    into enabled pixels to identify noisy pixels.
+'''
+
+import numpy as np
+import tables as tb
+
+from tqdm import tqdm
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    # Noise occupancy = min_occupancy / n_triggers
+    
+    # standard masking settings:
+    #'n_triggers': 1e7,   # Total number of triggers which are send
+    #'min_occupancy': 10  # All pixels with more hits than this threshold are masked as noisy
+    
+    # masking settings from Massimiliano:
+    'n_triggers': 1e7,     # Total number of triggers which are send
+    'min_occupancy': 1000  # All pixels with more hits than this threshold are masked as noisy
+    
+    # x-ray settings from Massimiliano:
+    #'n_triggers': 5e7,     # Total number of triggers which are send
+    #'min_occupancy': 1e19  # All pixels with more hits than this threshold are masked as noisy
+}
+
+
+class NoiseOccScan(ScanBase):
+    scan_id = 'noise_occupancy_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+        '''
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][:] = False
+        self.chip.masks.apply_disable_mask()
+
+        self.chip.masks.update(force=True)
+
+        # Disable injection
+        self.chip.enable_macro_col_cal(macro_cols=None)
+
+        # Do not abort on expecte RX errors
+        self.configuration['bench']['general']['abort_on_rx_error'] = False
+
+    def _scan(self, start_column=0, stop_column=400, start_row=0, stop_row=192, n_triggers=1e6, min_occupancy=1, wait_cycles=400, **_):
+        '''
+        Noise occupancy scan main loop
+
+        Parameters
+        ----------
+        n_triggers : int
+            Number of triggers to send.
+        wait_cycles : int
+            Time to wait in between trigger packages in units of sync commands.
+        '''
+
+        self.data.n_pixels = (stop_column - start_column) * (stop_row - start_row)
+        self.data.min_occupancy = min_occupancy
+        n = int(n_triggers / 32)  # Trigger command will always send 32 triggers
+        steps = []
+        while n > 0:
+            if n >= 50000:
+                steps.append(50000)
+                n -= 50000
+            else:
+                steps.append(n)
+                n -= n
+
+        # TODO: longterm solution may be to use inject_analog_single for all FE
+        # TODO: make CONF_LATENCY less
+        trigger_data = self.chip.write_sync(write=False)
+        trigger_data += self.chip.generate_trigger_command(0xffffffff)  # effectively we send x32 triggers
+        trigger_data += self.chip.write_sync(write=False) * wait_cycles
+
+        if start_column < 128 and self.chip.chip_type.lower() == 'rd53a':  # If SYNC enabled
+            self.log.info('SYNC enabled: Using analog injection based commnad.')
+            trigger_data = self.chip.inject_analog_single(send_ecr=True, wait_cycles=wait_cycles, write=False)
+
+        pbar = tqdm(total=n_triggers, unit=' Triggers', unit_scale=True)
+        with self.readout():
+            for stepsize in steps:
+                self.chip.write_command(trigger_data, repetitions=stepsize)
+                pbar.update(stepsize * 32)
+
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        self.configuration['bench']['analysis']['store_hits'] = True
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+            with tb.open_file(a.analyzed_data_file) as in_file:
+                occupancy = in_file.root.HistOcc[:].sum(axis=2)
+                disable_mask = ~(occupancy > self.data.min_occupancy)  # Mask everything larger than min. occupancy
+            n_disabled_pixels = np.count_nonzero(np.concatenate(np.invert(disable_mask)))
+            self.chip.masks.disable_mask &= disable_mask
+            self.chip.masks.apply_disable_mask()
+
+        self.log.success('Found and disabled {0} noisy pixels.'.format(n_disabled_pixels))
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+        return n_disabled_pixels, round(float(n_disabled_pixels) / float(self.data.n_pixels) * 100., 2), occupancy.sum(), disable_mask
+
+
+if __name__ == '__main__':
+    with NoiseOccScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step6_scan_stuck_pixel.py
+++ b/bdaq_xray_scripts/step6_scan_stuck_pixel.py
@@ -1,0 +1,105 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This scan identifies stuck pixels. Stuck pixels have such a low
+    threshold or are so noisy that the output of the comparator is
+    effectively always high.
+    It is important to identify these pixels and count them as "noisy"
+    during chip qualification and chip tuning.
+    Identifying stuck pixels is not completely straight forward
+    since they do not change the output of the comparator and thus show no
+    hits; the same result that not noisy pixels have.
+'''
+
+from tqdm import tqdm
+
+import numpy as np
+import tables as tb
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    # Warning: injecting into all pixels at once leads to n_injections-1 hits in a few pixels
+    # To catch all stuck pixels inject at least 2 times (n_injections=2)
+    'n_injections': 10
+}
+
+
+class StuckPixelScan(ScanBase):
+    scan_id = 'stuck_pixel_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+        '''
+
+        if start_column < 128 and self.chip.chip_type.lower() == 'rd53a':
+            self.log.warning('Stuck pixels in the SYNC FE cannot be identified by this algorithm and will be ignored!')
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][:] = False
+        self.chip.masks.apply_disable_mask()
+
+        self.chip.masks.update(force=True)
+        self.chip.write_cal(cal_edge_mode=0, cal_edge_width=1, cal_edge_dly=0)   # pixel CalEdge => 1
+
+    def _scan(self, n_injections=10, **_):
+        '''
+        Stuck pixel scan main loop
+
+        Parameters
+        ----------
+        n_injections : int
+            Number of injections.
+        '''
+        pbar = tqdm(total=self.chip.masks.get_mask_steps(), unit=' Mask steps')
+        with self.readout():
+            for fe, _ in self.chip.masks.shift(masks=['enable']):
+                if not fe == 'skipped' and not fe == 'SYNC':    # Ignore SYNC FE
+                    self.chip.toggle_output_select(send_ecr=False, repetitions=n_injections)
+                pbar.update(1)
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+        with tb.open_file(a.analyzed_data_file) as in_file:
+            occupancy = in_file.root.HistOcc[:].sum(axis=2)
+            not_stuck_pixel_mask = occupancy < 1
+            # Disabled mask has an inverted logic, thus & is needed
+            self.chip.masks.disable_mask &= not_stuck_pixel_mask
+            self.chip.masks.apply_disable_mask()
+
+        self.log.success('Found and disabled {0} stuck pixels.'.format(np.count_nonzero(~not_stuck_pixel_mask)))
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+                p._plot_occupancy(p.HistOcc[:, :, 0].T > 0, title='Stuck pixels', z_label='# of hits', z_min=0, z_max=1, show_sum=False)
+
+
+if __name__ == '__main__':
+    with StuckPixelScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step7_scan_noise_occupancy.py
+++ b/bdaq_xray_scripts/step7_scan_noise_occupancy.py
@@ -1,0 +1,138 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This basic scan sends triggers without injection
+    into enabled pixels to identify noisy pixels.
+'''
+
+import numpy as np
+import tables as tb
+
+from tqdm import tqdm
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    # Noise occupancy = min_occupancy / n_triggers
+    
+    # standard masking settings:
+    #'n_triggers': 1e7,   # Total number of triggers which are send
+    #'min_occupancy': 10  # All pixels with more hits than this threshold are masked as noisy
+    
+    # masking settings from Massimiliano:
+    'n_triggers': 1e7,     # Total number of triggers which are send
+    'min_occupancy': 1000  # All pixels with more hits than this threshold are masked as noisy
+    
+    # x-ray settings from Massimiliano:
+    #'n_triggers': 5e7,     # Total number of triggers which are send
+    #'min_occupancy': 1e19  # All pixels with more hits than this threshold are masked as noisy
+}
+
+
+class NoiseOccScan(ScanBase):
+    scan_id = 'noise_occupancy_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+        '''
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][:] = False
+        self.chip.masks.apply_disable_mask()
+
+        self.chip.masks.update(force=True)
+
+        # Disable injection
+        self.chip.enable_macro_col_cal(macro_cols=None)
+
+        # Do not abort on expecte RX errors
+        self.configuration['bench']['general']['abort_on_rx_error'] = False
+
+    def _scan(self, start_column=0, stop_column=400, start_row=0, stop_row=192, n_triggers=1e6, min_occupancy=1, wait_cycles=400, **_):
+        '''
+        Noise occupancy scan main loop
+
+        Parameters
+        ----------
+        n_triggers : int
+            Number of triggers to send.
+        wait_cycles : int
+            Time to wait in between trigger packages in units of sync commands.
+        '''
+
+        self.data.n_pixels = (stop_column - start_column) * (stop_row - start_row)
+        self.data.min_occupancy = min_occupancy
+        n = int(n_triggers / 32)  # Trigger command will always send 32 triggers
+        steps = []
+        while n > 0:
+            if n >= 50000:
+                steps.append(50000)
+                n -= 50000
+            else:
+                steps.append(n)
+                n -= n
+
+        # TODO: longterm solution may be to use inject_analog_single for all FE
+        # TODO: make CONF_LATENCY less
+        trigger_data = self.chip.write_sync(write=False)
+        trigger_data += self.chip.generate_trigger_command(0xffffffff)  # effectively we send x32 triggers
+        trigger_data += self.chip.write_sync(write=False) * wait_cycles
+
+        if start_column < 128 and self.chip.chip_type.lower() == 'rd53a':  # If SYNC enabled
+            self.log.info('SYNC enabled: Using analog injection based commnad.')
+            trigger_data = self.chip.inject_analog_single(send_ecr=True, wait_cycles=wait_cycles, write=False)
+
+        pbar = tqdm(total=n_triggers, unit=' Triggers', unit_scale=True)
+        with self.readout():
+            for stepsize in steps:
+                self.chip.write_command(trigger_data, repetitions=stepsize)
+                pbar.update(stepsize * 32)
+
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        self.configuration['bench']['analysis']['store_hits'] = True
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+            with tb.open_file(a.analyzed_data_file) as in_file:
+                occupancy = in_file.root.HistOcc[:].sum(axis=2)
+                disable_mask = ~(occupancy > self.data.min_occupancy)  # Mask everything larger than min. occupancy
+            n_disabled_pixels = np.count_nonzero(np.concatenate(np.invert(disable_mask)))
+            self.chip.masks.disable_mask &= disable_mask
+            self.chip.masks.apply_disable_mask()
+
+        self.log.success('Found and disabled {0} noisy pixels.'.format(n_disabled_pixels))
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+        return n_disabled_pixels, round(float(n_disabled_pixels) / float(self.data.n_pixels) * 100., 2), occupancy.sum(), disable_mask
+
+
+if __name__ == '__main__':
+    with NoiseOccScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step8_scan_threshold.py
+++ b/bdaq_xray_scripts/step8_scan_threshold.py
@@ -1,0 +1,115 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This script scans over different amounts of injected charge
+    to find the effective threshold of the enabled pixels.
+'''
+
+from tqdm import tqdm
+import numpy as np
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.chips.shift_and_inject import shift_and_inject, get_scan_loop_mask_steps
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    'VCAL_MED': 500,
+    'VCAL_HIGH_start': 625,
+    'VCAL_HIGH_stop': 820,
+    'VCAL_HIGH_step': 5
+}
+
+
+class ThresholdScan(ScanBase):
+    scan_id = 'threshold_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, TDAC=None, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+        TDAC : int / np.ndarray
+            If int: TDAC value to use for all enabled pixels, overwriting any existing mask.
+            If np.ndarray: TDAC mask to use for enabled pixels. Has to have shape to match start_column:stop_column, start_row:stop_row
+        '''
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks.apply_disable_mask()
+
+        if TDAC is not None:
+            if type(TDAC) == int:
+                self.chip.masks['tdac'][start_column:stop_column, start_row:stop_row] = TDAC
+            elif type(TDAC) == np.ndarray:
+                self.chip.masks['tdac'][start_column:stop_column, start_row:stop_row] = TDAC[start_column:stop_column, start_row:stop_row]
+
+        self.chip.masks.update(force=True)
+
+    def _scan(self, n_injections=100, VCAL_MED=500, VCAL_HIGH_start=1000, VCAL_HIGH_stop=4000, VCAL_HIGH_step=100, **_):
+        '''
+        Threshold scan main loop
+
+        Parameters
+        ----------
+        n_injections : int
+            Number of injections.
+
+        VCAL_MED : int
+            VCAL_MED DAC value.
+        VCAL_HIGH_start : int
+            First VCAL_HIGH value to scan.
+        VCAL_HIGH_stop : int
+            VCAL_HIGH value to stop the scan. This value is excluded from the scan.
+        VCAL_HIGH_step : int
+            VCAL_HIGH interval.
+        '''
+
+        vcal_high_range = range(VCAL_HIGH_start, VCAL_HIGH_stop, VCAL_HIGH_step)
+
+        pbar = tqdm(total=get_scan_loop_mask_steps(scan=self) * len(vcal_high_range), unit=' Mask steps')
+        for scan_param_id, vcal_high in enumerate(vcal_high_range):
+            self.chip.setup_analog_injection(vcal_high=vcal_high, vcal_med=VCAL_MED)
+            with self.readout(scan_param_id=scan_param_id):
+                shift_and_inject(scan=self, n_injections=n_injections, pbar=pbar, scan_param_id=scan_param_id)
+
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+            mean_thr = np.median(a.threshold_map[np.nonzero(a.threshold_map)])
+            mean_noise = np.median(a.noise_map[np.nonzero(a.noise_map)])
+            if np.isfinite(mean_thr):
+                self.log.info('Mean threshold is %i [Delta VCAL]' % (int(mean_thr)))
+            else:
+                self.log.warning('Mean threshold could not be determined!')
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+        return mean_thr, mean_noise
+
+
+if __name__ == '__main__':
+    with ThresholdScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step9_scan_noise_occupancy.py
+++ b/bdaq_xray_scripts/step9_scan_noise_occupancy.py
@@ -1,0 +1,138 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+'''
+    This basic scan sends triggers without injection
+    into enabled pixels to identify noisy pixels.
+'''
+
+import numpy as np
+import tables as tb
+
+from tqdm import tqdm
+
+from bdaq53.system.scan_base import ScanBase
+from bdaq53.analysis import analysis
+from bdaq53.analysis import plotting
+
+scan_configuration = {
+    'start_column': 0,
+    'stop_column': 400,
+    'start_row': 0,
+    'stop_row': 192,
+
+    # Noise occupancy = min_occupancy / n_triggers
+    
+    # standard masking settings:
+    #'n_triggers': 1e7,   # Total number of triggers which are send
+    #'min_occupancy': 10  # All pixels with more hits than this threshold are masked as noisy
+    
+    # masking settings from Massimiliano:
+    #'n_triggers': 1e7,     # Total number of triggers which are send
+    #'min_occupancy': 1000  # All pixels with more hits than this threshold are masked as noisy
+    
+    # x-ray settings from Massimiliano:
+    'n_triggers': 5e7,     # Total number of triggers which are send
+    'min_occupancy': 1e19  # All pixels with more hits than this threshold are masked as noisy
+}
+
+
+class NoiseOccScan(ScanBase):
+    scan_id = 'noise_occupancy_scan'
+
+    def _configure(self, start_column=0, stop_column=400, start_row=0, stop_row=192, **_):
+        '''
+        Parameters
+        ----------
+        start_column : int [0:400]
+            First column to scan
+        stop_column : int [0:400]
+            Column to stop the scan. This column is excluded from the scan.
+        start_row : int [0:192]
+            First row to scan
+        stop_row : int [0:192]
+            Row to stop the scan. This row is excluded from the scan.
+        '''
+
+        self.chip.masks['enable'][start_column:stop_column, start_row:stop_row] = True
+        self.chip.masks['injection'][:] = False
+        self.chip.masks.apply_disable_mask()
+
+        self.chip.masks.update(force=True)
+
+        # Disable injection
+        self.chip.enable_macro_col_cal(macro_cols=None)
+
+        # Do not abort on expecte RX errors
+        self.configuration['bench']['general']['abort_on_rx_error'] = False
+
+    def _scan(self, start_column=0, stop_column=400, start_row=0, stop_row=192, n_triggers=1e6, min_occupancy=1, wait_cycles=400, **_):
+        '''
+        Noise occupancy scan main loop
+
+        Parameters
+        ----------
+        n_triggers : int
+            Number of triggers to send.
+        wait_cycles : int
+            Time to wait in between trigger packages in units of sync commands.
+        '''
+
+        self.data.n_pixels = (stop_column - start_column) * (stop_row - start_row)
+        self.data.min_occupancy = min_occupancy
+        n = int(n_triggers / 32)  # Trigger command will always send 32 triggers
+        steps = []
+        while n > 0:
+            if n >= 50000:
+                steps.append(50000)
+                n -= 50000
+            else:
+                steps.append(n)
+                n -= n
+
+        # TODO: longterm solution may be to use inject_analog_single for all FE
+        # TODO: make CONF_LATENCY less
+        trigger_data = self.chip.write_sync(write=False)
+        trigger_data += self.chip.generate_trigger_command(0xffffffff)  # effectively we send x32 triggers
+        trigger_data += self.chip.write_sync(write=False) * wait_cycles
+
+        if start_column < 128 and self.chip.chip_type.lower() == 'rd53a':  # If SYNC enabled
+            self.log.info('SYNC enabled: Using analog injection based commnad.')
+            trigger_data = self.chip.inject_analog_single(send_ecr=True, wait_cycles=wait_cycles, write=False)
+
+        pbar = tqdm(total=n_triggers, unit=' Triggers', unit_scale=True)
+        with self.readout():
+            for stepsize in steps:
+                self.chip.write_command(trigger_data, repetitions=stepsize)
+                pbar.update(stepsize * 32)
+
+        pbar.close()
+        self.log.success('Scan finished')
+
+    def _analyze(self):
+        self.configuration['bench']['analysis']['store_hits'] = True
+        with analysis.Analysis(raw_data_file=self.output_filename + '.h5', **self.configuration['bench']['analysis']) as a:
+            a.analyze_data()
+            with tb.open_file(a.analyzed_data_file) as in_file:
+                occupancy = in_file.root.HistOcc[:].sum(axis=2)
+                disable_mask = ~(occupancy > self.data.min_occupancy)  # Mask everything larger than min. occupancy
+            n_disabled_pixels = np.count_nonzero(np.concatenate(np.invert(disable_mask)))
+            self.chip.masks.disable_mask &= disable_mask
+            self.chip.masks.apply_disable_mask()
+
+        self.log.success('Found and disabled {0} noisy pixels.'.format(n_disabled_pixels))
+
+        if self.configuration['bench']['analysis']['create_pdf']:
+            with plotting.Plotting(analyzed_data_file=a.analyzed_data_file) as p:
+                p.create_standard_plots()
+
+        return n_disabled_pixels, round(float(n_disabled_pixels) / float(self.data.n_pixels) * 100., 2), occupancy.sum(), disable_mask
+
+
+if __name__ == '__main__':
+    with NoiseOccScan(scan_config=scan_configuration) as scan:
+        scan.start()

--- a/bdaq_xray_scripts/step9b_scan_noise_occupancy.py
+++ b/bdaq_xray_scripts/step9b_scan_noise_occupancy.py
@@ -36,7 +36,7 @@ scan_configuration = {
     #'min_occupancy': 1000  # All pixels with more hits than this threshold are masked as noisy
     
     # x-ray settings from Massimiliano:
-    'n_triggers': 5e7,     # Total number of triggers which are sent
+    'n_triggers': 1e8,     # Total number of triggers which are sent
     'min_occupancy': 1e19  # All pixels with more hits than this threshold are masked as noisy
 }
 

--- a/process/extrapolation.py
+++ b/process/extrapolation.py
@@ -121,6 +121,7 @@ def runSet(base_plot_dir, base_data_dir, cable_number=-1, output_csv_dir="", out
             # last_row  = table[-1]
             # min_value = last_row[2]
             # print("$--- {0}: e-link {1}, min value = {2}".format(name, number_from_name, min_value),'\n')
+            print("e-link: {0}, name: {1}, number_from_name: {2}".format(cable_number, name, number_from_name))
     
     #print(table)
     


### PR DESCRIPTION
New bdaq scripts for RD53A quad modules
- Use when taking x-ray data to test bump bonds
- Procedure from Massimiliano Antonello