### PR TITLE
Updates from 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,19 +455,32 @@ To copy the plots to your local computer, use this script from this repository:
 
 ## Digital module (1x2 CROC digital module) 
 
+### Power Settings
+
+We are powering the port card in constant votlage mode.
+We put the power cables on one power suppy output channel (on the left side of the power supply),
+with the white cable on positive and the black cable on negative.
+
+For the port card, we are using constant voltage mode with these settings:
+- Voltage limit: 10.16 V - should measure about 10.17 V when output is on.
+- Current limit:  0.80 A - should measure about  0.15 A when output is on.
+
+We are powering the digital module in constant current mode.
+We put both power cables on one power supply output channel (on the right side of the power supply),
+with both red cables on positive and both black cables on negative.
+
+For the digital module, we are using constant current mode with these settings:
+- Current limit: 3.80 A - should measure about 3.80 A when output is on.
+- Voltage limit: 1.70 V - should measure about 1.63 V when output is on.
+
+### Electrical readout
+
 For electrical readout of the RD53B 1x2 CROC digital module,
 we are using the KSU FMC in slot L12 of the FC7 (the slot on the right).
 The digital module should connect to the KSU FMC (in the upper left port) using a mini-DP cable.
 
-To power the digital module, we are putting both power cables on one power supply output channel,
-with both red cables on positive and both black cables on negative.
-The power cable should connect to the connector on the digital module.
-We are using constant voltage mode with these settings:
-- Total voltage: 1.70 V on the supply (1.68 V with multimeter)
-- Total current: 4.25 A on the supply
-
 We are using Ph2_ACF tag v4-13,
-and we are using firmware v4.6 for KSU (L12) electrical readout for CROCv1 QUAD modules.
+and we are using FC7 firmware v4.6 for KSU (L12) electrical readout for CROCv1 QUAD modules.
 
 Setup:
 ```
@@ -486,4 +499,62 @@ CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c bertest
 CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c pixelalive
 CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c scurve
 ```
+
+### Optical readout
+
+For optical readout of the RD53B 1x2 CROC digital module,
+we are using the optical FMC in slot L8 of the FC7 (the slot on the left).
+The port card should connect to the optical FMC using an optical fiber;
+the optical fiber channels 6 and 7 should be connected to the leftmost position of the bottom row of the optical FMC.
+We are using a "TFPX H1x2 K" e-link (e-link 520),
+with the 15-pin connector P1 installed on the digital module
+and the 45-pin connector installed on port card slot J4.
+
+Here are the software and firmware versions that we are using (as of December 14, 2023).
+For Ph2_ACF, we are using the Ph2_ACF tag v4-18.
+We are using FC7 firmware v4.8 for optical readout (L8), quad module, and CROCv1.   
+Note that we are using a dedicated working area for modules in kucms at this path:
+```
+/home/kucms/TrackerDAQ/modules/Ph2_ACF
+```
+
+RD53B digital module optical readout:
+
+Setup:
+```
+cd /home/kucms/TrackerDAQ/modules/Ph2_ACF
+source setup.sh
+cd DAQSettings_v1
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -i IT-L8-OPTO-CROC_QUAD_v4p8
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -r
+ping fc7 -c 3
+```
+
+Run tests:
+```
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -c pixelalive
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -c scurve
+```
+
+To resolve the "LpGBT PUSM status: ARESET" error, reprogram and reset the FC7 using these commands:
+```
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -i IT-L8-OPTO-CROC_QUAD_v4p8
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -r
+```
+
+Here is the command to run BERT TAP0 scans:
+```
+python3 TrackerDAQ/python/BERT_Run_Scan.py
+```
+
+Use this script to analyze RD53B data for one e-link or all e-links.
+```
+# specific e-link
+./TrackerDAQ/scripts/analyze_RD53B.sh 520
+# all e-links
+./TrackerDAQ/scripts/analyze_RD53B.sh
+```
+
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,27 @@ To copy the plots to your local computer, use this script from this repository:
 
 ## Digital module (1x2 CROC digital module) 
 
-TODO: Document digital module electrical readout.
+TODO: Finish digital module electrical readout instructions (power settings, etc.).
+
+RD53B digital module electrical readout:
+
+Setup:
+```
+cd /home/kucms/TrackerDAQ/croc/Ph2_ACF
+source setup.sh
+cd DAQSettings_v3
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Electrical.xml -i IT-L12-KSU-CROC_QUAD_v4p6
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -r
+ping fc7 -c 3
+```
+
+Run tests:
+```
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c pixelalive
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c scurve
+```
+
 
 

--- a/README.md
+++ b/README.md
@@ -453,3 +453,8 @@ To copy the plots to your local computer, use this script from this repository:
 ./scripts/getPlots.sh
 ```
 
+## Digital module (1x2 CROC digital module) 
+
+TODO: Document digital module electrical readout.
+
+

--- a/README.md
+++ b/README.md
@@ -142,23 +142,23 @@ fpgaconfig --help
 ```
 Load FC7 firmware from SD card:
 ```
-fpgaconfig -c <config_file.xml> -i <FW_File_SD>
+fpgaconfig -c <xml_config_file> -i <FW_File_SD>
 ```
 Reset FC7 after loading firmware:
 ```
-CMSITminiDAQ -f <config_file.xml> -r
+CMSITminiDAQ -f <xml_config_file> -r
 ```
 List available FC7 firmware versions loaded on the SD card:
 ```
-fpgaconfig -c CMSIT.xml -l
+fpgaconfig -c <xml_config_file> -l
 ```
 Load new FC7 firmware onto the SD card:
 ```
-fpgaconfig -c <config_file.xml> -f <FW_File_PC> -i <FW_File_SD>
+fpgaconfig -c <xml_config_file> -f <FW_File_PC> -i <FW_File_SD>
 ```
 Delete FC7 firmware from SD card:
 ```
-fpgaconfig  -c <config_file.xml> -d <FW_File_SD>
+fpgaconfig  -c <xml_config_file> -d <FW_File_SD>
 ```
 
 # Using RD53A chips 

--- a/README.md
+++ b/README.md
@@ -455,9 +455,19 @@ To copy the plots to your local computer, use this script from this repository:
 
 ## Digital module (1x2 CROC digital module) 
 
-TODO: Finish digital module electrical readout instructions (power settings, etc.).
+For electrical readout of the RD53B 1x2 CROC digital module,
+we are using the KSU FMC in slot L12 of the FC7 (the slot on the right).
+The digital module should connect to the KSU FMC (in the upper left port) using a mini-DP cable.
 
-RD53B digital module electrical readout:
+To power the digital module, we are putting both power cables on one power supply output channel,
+with both red cables on positive and both black cables on negative.
+The power cable should connect to the connector on the digital module.
+We are using constant voltage mode with these settings:
+- Total voltage: 1.70 V on the supply (1.68 V with multimeter)
+- Total current: 4.25 A on the supply
+
+We are using Ph2_ACF tag v4-13,
+and we are using firmware v4.6 for KSU (L12) electrical readout for CROCv1 QUAD modules.
 
 Setup:
 ```
@@ -476,6 +486,4 @@ CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c bertest
 CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c pixelalive
 CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c scurve
 ```
-
-
 

--- a/docs/commands_v3.txt
+++ b/docs/commands_v3.txt
@@ -1,0 +1,196 @@
+RD53B Testing
+
+# References:
+https://github.com/ku-cms/TrackerDAQ
+https://gitlab.cern.ch/cms_tk_ph2/Ph2_ACF
+
+# Installation:
+
+First, follow the instructions in the "Setup on CentOs7" section here, including all required packages:
+https://gitlab.cern.ch/cms_tk_ph2/Ph2_ACF
+
+# Install Ph2_ACF:
+git clone --recurse-submodules https://gitlab.cern.ch/cms_tk_ph2/Ph2_ACF.git
+cd Ph2_ACF
+source setup.sh
+mkdir build
+cd build
+cmake3 ..
+make -j8 
+cd ..
+
+# Checkout a new version (using a tag) and update the submodules (MessageUtils and NetworkUtils);
+# there can be compile errors if you do not update the submodules:
+git checkout <tag_name>
+git submodule sync
+git submodule update --init --recursive --remote
+
+# Note: We use cmake3, which was installed with yum.
+
+# Full recompile
+source setup.sh
+rm -rf build
+mkdir build
+cd build
+cmake3 ..
+make -j8 
+cd ..
+
+# Compile (only make)
+source setup.sh
+cd build
+make -j8 
+cd ..
+
+Setup Ph2_ACF working area; choose a directory name (using DAQSettings_v1 for this example):
+
+mkdir -p DAQSettings_v1
+cp settings/RD53Files/CMSIT*.txt DAQSettings_v1
+cp settings/CMSIT*.xml DAQSettings_v1
+cd DAQSettings_v1
+
+Edit the "connection" line in these files with your FC7 IP address (e.g. 192.168.1.100):
+CMSIT_RD53A.xml
+CMSIT_RD53B.xml
+
+move to:
+CMSIT_RD53A_Electrical.xml
+CMSIT_RD53B_Electrical.xml
+
+copy to new xml for optical:
+CMSIT_RD53A_Optical.xml
+CMSIT_RD53B_Optical.xml
+
+Example connection line for 192.168.1.100:
+<connection id="nanocrate" uri="ipbusudp-2.0://192.168.1.100:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
+
+Setup FC7:
+Load new firmware onto SD card:
+
+RD53B optical readout:
+fpgaconfig -c CMSIT_RD53B_Optical.xml -l
+fpgaconfig -c CMSIT_RD53B_Optical.xml -f IT-uDTC_L8-OPTO-4xSCC_OPTICAL_CROC_v4.5.bit -i IT-L8-OPTO_CROC_v4p5
+fpgaconfig -c CMSIT_RD53B_Optical.xml -l
+
+RD53A quad module electrical readout:
+fpgaconfig -c CMSIT_RD53A_Electrical.xml -l
+fpgaconfig -c CMSIT_RD53A_Electrical.xml -f IT-uDTC_L12-KSU-3xQUAD_L8-DIO5_ELECTRICAL_RD53A_v4.5.bit -i IT-L12-KSU-RD53A_QUAD_v4p5
+fpgaconfig -c CMSIT_RD53A_Electrical.xml -l
+
+RD53B digital module electrical readout:
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Electrical.xml -l
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Electrical.xml -f FC7_firmware/RD53B_Digital_Module/IT-uDTC_L12-KSU-3xQUAD_L8-KSU-2xQUAD_ELECTRICAL_CROC_v4.6.bit -i IT-L12-KSU-CROC_QUAD_v4p6
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Electrical.xml -l
+
+RD53B digital module optical readout:
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -l
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -f FC7_firmware/RD53B_Digital_Module/IT-uDTC_L8-OPTO-4xQUAD_OPTICAL_CROC_v4.6.bit -i IT-L8-OPTO-CROC_QUAD_v4p6
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -l
+
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -l
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -f FC7_firmware/RD53B_Digital_Module/IT-uDTC_L8-OPTO-4xQUAD_OPTICAL_CROC_v4.8.bit -i IT-L8-OPTO-CROC_QUAD_v4p8
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -l
+
+Load firmware: 
+
+RD53B optical readout:
+fpgaconfig -c CMSIT_RD53B_Optical.xml -i IT-L8-OPTO_CROC_v4p5
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -r
+
+RD53B digital module electrical readout:
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Electrical.xml -i IT-L12-KSU-CROC_QUAD_v4p6
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -r
+
+RD53B digital module optical readout:
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -i IT-L8-OPTO-CROC_QUAD_v4p6
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -r
+
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -i IT-L8-OPTO-CROC_QUAD_v4p8
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -r
+
+Test:
+
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -c bertest
+
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c bertest
+
+Get lpGBT settings:
+cp settings/lpGBTFiles/CMSIT_LpGBT-v1.txt DAQSettings_v1
+
+-------------------------------------
+RD53A quad module electrical readout procedure:
+
+Setup:
+cd /home/kucms/TrackerDAQ/croc/Ph2_ACF
+source setup.sh
+cd DAQSettings_v2
+fpgaconfig -c CMSIT_RD53A_Electrical.xml -i IT-L12-KSU-RD53A_QUAD_v4p5
+CMSITminiDAQ -f CMSIT_RD53A_Electrical.xml -r
+ping fc7 -c 3
+
+Run tests:
+CMSITminiDAQ -f CMSIT_RD53A_Electrical.xml -p
+CMSITminiDAQ -f CMSIT_RD53A_Electrical.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53A_Electrical.xml -c pixelalive 
+CMSITminiDAQ -f CMSIT_RD53A_Electrical.xml -c scurve
+-------------------------------------
+RD53B digital module electrical readout:
+
+Setup:
+cd /home/kucms/TrackerDAQ/croc/Ph2_ACF
+source setup.sh
+cd DAQSettings_v3
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Electrical.xml -i IT-L12-KSU-CROC_QUAD_v4p6
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -r
+ping fc7 -c 3
+
+Run tests:
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c pixelalive
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Electrical.xml -c scurve
+-------------------------------------
+RD53B digital module optical readout:
+
+Setup:
+cd /home/kucms/TrackerDAQ/croc/Ph2_ACF
+source setup.sh
+cd DAQSettings_v3
+fpgaconfig -c CMSIT_RD53B_Digital_Module_Optical_J4.xml -i IT-L8-OPTO-CROC_QUAD_v4p8
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -r
+ping fc7 -c 3
+
+Run tests:
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -c pixelalive
+CMSITminiDAQ -f CMSIT_RD53B_Digital_Module_Optical_J4.xml -c scurve
+-------------------------------------
+RD53B optical readout procedure:
+
+DAQ Settings versions:
+DAQSettings_v1
+DAQSettings_v3
+
+cd /home/kucms/TrackerDAQ/croc/Ph2_ACF
+source setup.sh
+cd DAQSettings_v3
+fpgaconfig -c CMSIT_RD53B_Optical.xml -i IT-L8-OPTO_CROC_v4p5
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -r
+ping fc7 -c 3
+
+For e-link in J2:
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -c pixelalive
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -c noise
+CMSITminiDAQ -f CMSIT_RD53B_Optical.xml -c scurve
+
+For e-link in J3:
+CMSITminiDAQ -f CMSIT_RD53B_Optical_J3.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Optical_J3.xml -c bertest
+-------------------------------------
+
+

--- a/python/BERT_Plot.py
+++ b/python/BERT_Plot.py
@@ -4,7 +4,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from tools import makeDir
 
-def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Bit errors over 20 seconds", setLogY=True, y_errors=[]):
+# Change y-axis label based on BERT; bits/frams and time
+#def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Bit errors over 20 seconds", setLogY=True, y_errors=[]):
+def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Frame errors over 10 seconds", setLogY=True, y_errors=[]):
     useXKCDStyle = False    # Use XKCD style
     setAxisLimits = False   # Use assigned axis limits
 

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -15,14 +15,14 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Medium TAP0 range
-    tap0_min    = 200
-    tap0_max    = 500
-    tap0_step   = 10
+    #tap0_min    = 200
+    #tap0_max    = 500
+    #tap0_step   = 10
     
     # Large TAP0 range
-    #tap0_min    = 100
-    #tap0_max    = 1000
-    #tap0_step   = 100
+    tap0_min    = 100
+    tap0_max    = 1000
+    tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!
@@ -54,8 +54,8 @@ def getDefaultInputs(cable_number, channel):
     #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J3_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
     
     # RD53B + port card with e-link in J4:
-    output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
-    #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+    #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+    output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
 
     inputs["tap0_min"]      = tap0_min
     inputs["tap0_max"]      = tap0_max

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -10,9 +10,9 @@ def getDefaultInputs(cable_number, channel):
     inputs      = {}
     
     # Small TAP0 range
-    #tap0_min    = 20
-    #tap0_max    = 200
-    #tap0_step   = 10
+    tap0_min    = 50
+    tap0_max    = 200
+    tap0_step   = 10
     
     # Medium TAP0 range
     #tap0_min    = 100
@@ -20,9 +20,9 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Large TAP0 range
-    tap0_min    = 100
-    tap0_max    = 1000
-    tap0_step   = 100
+    #tap0_min    = 100
+    #tap0_max    = 1000
+    #tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -10,9 +10,9 @@ def getDefaultInputs(cable_number, channel):
     inputs      = {}
     
     # Small TAP0 range
-    #tap0_min    = 50
-    #tap0_max    = 150
-    #tap0_step   = 10
+    tap0_min    = 30
+    tap0_max    = 100
+    tap0_step   = 10
     
     # Medium TAP0 range
     #tap0_min    = 200
@@ -20,9 +20,9 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Large TAP0 range
-    tap0_min    = 100
-    tap0_max    = 1000
-    tap0_step   = 100
+    #tap0_min    = 100
+    #tap0_max    = 1000
+    #tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -10,19 +10,19 @@ def getDefaultInputs(cable_number, channel):
     inputs      = {}
     
     # Small TAP0 range
-    tap0_min    = 30
-    tap0_max    = 100
-    tap0_step   = 10
+    #tap0_min    = 20
+    #tap0_max    = 200
+    #tap0_step   = 10
     
     # Medium TAP0 range
-    #tap0_min    = 200
-    #tap0_max    = 500
+    #tap0_min    = 100
+    #tap0_max    = 300
     #tap0_step   = 10
     
     # Large TAP0 range
-    #tap0_min    = 100
-    #tap0_max    = 1000
-    #tap0_step   = 100
+    tap0_min    = 100
+    tap0_max    = 1000
+    tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -10,9 +10,9 @@ def getDefaultInputs(cable_number, channel):
     inputs      = {}
     
     # Small TAP0 range
-    tap0_min    = 50
-    tap0_max    = 150
-    tap0_step   = 10
+    #tap0_min    = 50
+    #tap0_max    = 150
+    #tap0_step   = 10
     
     # Medium TAP0 range
     #tap0_min    = 100
@@ -20,9 +20,9 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Large TAP0 range
-    #tap0_min    = 100
-    #tap0_max    = 1000
-    #tap0_step   = 100
+    tap0_min    = 100
+    tap0_max    = 1000
+    tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -11,7 +11,7 @@ def getDefaultInputs(cable_number, channel):
     
     # Small TAP0 range
     tap0_min    = 50
-    tap0_max    = 200
+    tap0_max    = 150
     tap0_step   = 10
     
     # Medium TAP0 range
@@ -55,7 +55,12 @@ def getDefaultInputs(cable_number, channel):
     
     # RD53B + port card with e-link in J4:
     #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
-    output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+    #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+
+    # Module + port card with e-link in J4:
+    output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+
+    # FIXME: add directory for digital module and e-link: no DP cable or adapter board
 
     inputs["tap0_min"]      = tap0_min
     inputs["tap0_max"]      = tap0_max

--- a/python/BERT_Simple_Analyze.py
+++ b/python/BERT_Simple_Analyze.py
@@ -216,8 +216,13 @@ def analyzeScansRD53B(cable_number):
     #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     # using port card with e-link in J4 with red adapter board:
-    base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
-    base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    #base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    #base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
+    
+    # using port card with e-link in J4 with module:
+    base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module"
+    base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module"
     output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     #base_plot_dir    = "plots/BERT_TAP0_Scans/SingleDP"

--- a/python/BERT_Simple_Analyze.py
+++ b/python/BERT_Simple_Analyze.py
@@ -211,14 +211,14 @@ def analyzeScansRD53B(cable_number):
     #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     # using port card with e-link in J4, SMA adapter boards and cables:
-    base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter"
-    base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter"
-    output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
+    #base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter"
+    #base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter"
+    #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     # using port card with e-link in J4 with red adapter board:
-    #base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
-    #base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
-    #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
+    base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     #base_plot_dir    = "plots/BERT_TAP0_Scans/SingleDP"
     #base_data_dir    = "data/BERT_TAP0_Scans/SingleDP"

--- a/scripts/PortCard_BERT_Scan.sh
+++ b/scripts/PortCard_BERT_Scan.sh
@@ -47,7 +47,12 @@ mkdir -p "$dataDir"
 
 
 cp CMSIT_RD53B_Optical_BERT.xml CMSIT_RD53B_Optical_BERT_Custom.xml
-sed -i -e "s|DAC_CML_BIAS_0         =   \"500\"|DAC_CML_BIAS_0         =   \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
+
+# FIXME: We should find a better way to do this that does not break based on the number of spaces!!
+
+# Be careful about the number of spaces!
+#sed -i -e "s|DAC_CML_BIAS_0         =   \"500\"|DAC_CML_BIAS_0         =   \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
+sed -i -e "s|DAC_CML_BIAS_0         =    \"500\"|DAC_CML_BIAS_0         =    \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
 
 # Run BERT and send output to file
 echo "Running BERT with TAP0=$TAP0_Setting" | tee -a $outFile

--- a/scripts/getPlots.sh
+++ b/scripts/getPlots.sh
@@ -7,6 +7,7 @@
 #rsync -az kucms@kucms-01.phsx.ku.edu:/home/kucms/TrackerDAQ/croc/Ph2_ACF/DAQSettings_v1/plots/ raw_plots_RD53B
 
 # kucms
-rsync -az kucms@kucms.phsx.ku.edu:/home/kucms/TrackerDAQ/croc/Ph2_ACF/DAQSettings_v3/plots/ raw_plots_PortCard_RD53B
 rsync -az kucms@kucms.phsx.ku.edu:/home/kucms/TrackerDAQ/update/Ph2_ACF/DAQSettings_v1/plots/ raw_plots_RD53A
+rsync -az kucms@kucms.phsx.ku.edu:/home/kucms/TrackerDAQ/croc/Ph2_ACF/DAQSettings_v3/plots/ raw_plots_PortCard_RD53B
+rsync -az kucms@kucms.phsx.ku.edu:/home/kucms/TrackerDAQ/modules/Ph2_ACF/DAQSettings_v1/plots/ raw_plots_PortCard_Module
 

--- a/settings/CMSIT_RD53B_Digital_Module_Optical_J4.xml
+++ b/settings/CMSIT_RD53B_Digital_Module_Optical_J4.xml
@@ -1,26 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <HwDescription>
-  <BeBoard Id="0" boardType="RD53" eventType="VR"  configure="1">
-    <connection id="cmsinnertracker.crate0.slot0" uri="chtcp-2.0://localhost:10203?target=192.168.1.11:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
+  <BeBoard Id="0" boardType="RD53" eventType="VR" configure="1">
+    <connection id="nanocrate" uri="ipbusudp-2.0://192.168.1.100:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
     <!---
         <connection id="cmsinnertracker.crate0.slot0" uri="ipbusudp-2.0://192.168.1.80:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
     -->
 
     <!-- Frontend chip configuration -->
-  <OpticalGroup Id="0" FMCId="0">
-   <lpGBT_Files path="${PWD}/" />
+    <OpticalGroup Id="0" FMCId="0">
+      <lpGBT_Files path="${PWD}/" />
       <lpGBT Id="0" version="1" configfile="CMSIT_LpGBT-v1.txt" ChipAddress="0x73" RxDataRate="1280" RxHSLPolarity="0" TxDataRate="160" TxHSLPolarity="0">
         <Settings/>
-      </lpGBT> 
+      </lpGBT>
       <Hybrid Id="0" enable="1">
         <RD53_Files path="${PWD}/" />
 
-
         <!-- Available Comment fields are: 50x50, 25x100origR0C0, 25x100origR1C0, unknown, combined with RD53A, RD53B, dual, quad -->
-        <RD53B Id="12" Lane="0" configfile="CMSIT_RD53B_RH0007_12.txt" RxGroups="2" RxChannels="0" RxPolarities="1" TxGroups="1" TxChannels="2" TxPolarities="0" Comment="RD53B 50x50">
-          <!--LaneConfig primary="1" outputLanes="0001" singleChannelInputs="0000" dualChannelInput="0000" /-->
-          <LaneConfig primary="1" outputLanes="0001" singleChannelInputs="0000" dualChannelInput="0000" />
+        <RD53B Id="12" Lane="0" configfile="CMSIT_RD53B_RH0005_12.txt" RxGroups="2" RxChannels="0" RxPolarities="1" TxGroups="1" TxChannels="2" TxPolarities="0" Comment="RD53B 50x50">
+          <LaneConfig primary="1" master="0" outputLanes="0001" singleChannelInputs="0000" dualChannelInput="0000" />
           <!-- Overwrite .txt configuration file settings -->
           <Settings
               DAC_PREAMP_L_LIN       =    "300"

--- a/settings/CMSIT_RD53B_Digital_Module_Optical_J4.xml
+++ b/settings/CMSIT_RD53B_Digital_Module_Optical_J4.xml
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<HwDescription>
+  <BeBoard Id="0" boardType="RD53" eventType="VR"  configure="1">
+    <connection id="cmsinnertracker.crate0.slot0" uri="chtcp-2.0://localhost:10203?target=192.168.1.11:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
+    <!---
+        <connection id="cmsinnertracker.crate0.slot0" uri="ipbusudp-2.0://192.168.1.80:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
+    -->
+
+    <!-- Frontend chip configuration -->
+  <OpticalGroup Id="0" FMCId="0">
+   <lpGBT_Files path="${PWD}/" />
+      <lpGBT Id="0" version="1" configfile="CMSIT_LpGBT-v1.txt" ChipAddress="0x73" RxDataRate="1280" RxHSLPolarity="0" TxDataRate="160" TxHSLPolarity="0">
+        <Settings/>
+      </lpGBT> 
+      <Hybrid Id="0" enable="1">
+        <RD53_Files path="${PWD}/" />
+
+
+        <!-- Available Comment fields are: 50x50, 25x100origR0C0, 25x100origR1C0, unknown, combined with RD53A, RD53B, dual, quad -->
+        <RD53B Id="12" Lane="0" configfile="CMSIT_RD53B_RH0007_12.txt" RxGroups="2" RxChannels="0" RxPolarities="1" TxGroups="1" TxChannels="2" TxPolarities="0" Comment="RD53B 50x50">
+          <!--LaneConfig primary="1" outputLanes="0001" singleChannelInputs="0000" dualChannelInput="0000" /-->
+          <LaneConfig primary="1" outputLanes="0001" singleChannelInputs="0000" dualChannelInput="0000" />
+          <!-- Overwrite .txt configuration file settings -->
+          <Settings
+              DAC_PREAMP_L_LIN       =    "300"
+              DAC_PREAMP_R_LIN       =    "300"
+              DAC_PREAMP_TL_LIN      =    "300"
+              DAC_PREAMP_TR_LIN      =    "300"
+              DAC_PREAMP_T_LIN       =    "300"
+              DAC_PREAMP_M_LIN       =    "300"
+              DAC_FC_LIN             =     "20"
+              DAC_KRUM_CURR_LIN      =     "70"
+              DAC_REF_KRUM_LIN       =    "360"
+              DAC_COMP_LIN           =    "110"
+              DAC_COMP_TA_LIN        =    "110"
+              DAC_GDAC_L_LIN         =    "450"
+              DAC_GDAC_R_LIN         =    "450"
+              DAC_GDAC_M_LIN         =    "450"
+              DAC_LDAC_LIN           =    "140"
+
+              VCAL_HIGH              =   "2000"
+              VCAL_MED               =    "100"
+
+              GP_LVDS_ROUTE_0        =   "1495"
+              GP_LVDS_ROUTE_1        =   "1495"
+              TriggerConfig          =    "136"
+              CLK_DATA_DELAY         =      "0"
+              CAL_EDGE_FINE_DELAY    =      "0"
+              ANALOG_INJ_MODE        =      "0"
+              SEL_CAL_RANGE          =      "0"
+
+              SelfTriggerEn          =      "0"
+              SelfTriggerDelay       =     "30"
+              EnOutputDataChipId     =      "1"
+
+              VOLTAGE_TRIM_DIG       =      "8"
+              VOLTAGE_TRIM_ANA       =      "8"
+
+              CML_CONFIG_SER_EN_TAP  =   "0b00"
+              CML_CONFIG_SER_INV_TAP =   "0b00"
+              DAC_CML_BIAS_0         =    "500"
+              DAC_CML_BIAS_1         =      "0"
+              DAC_CML_BIAS_2         =      "0"
+
+              MON_ADC_TRIM           =      "5"
+
+              ToT6to4Mapping         =      "0"
+              ToTDualEdgeCount       =      "0"
+
+              RESISTORI2V            =   "5000"
+              ADC_OFFSET_VOLT        =     "63"
+              ADC_MAXIMUM_VOLT       =    "839"
+              TEMPSENS_IDEAL_FACTOR  =   "1225"
+              SAMPLE_N_TIMES         =     "10"
+              VREF_ADC               =    "800"
+              />
+        </RD53B>
+
+        <Global
+            EN_CORE_COL_0            =  "65535"
+            EN_CORE_COL_1            =  "65535"
+            EN_CORE_COL_2            =  "65535"
+            EN_CORE_COL_3            =     "63"
+
+            EN_CORE_COL_CAL_0        =  "65535"
+            EN_CORE_COL_CAL_1        =  "65535"
+            EN_CORE_COL_CAL_2        =  "65535"
+            EN_CORE_COL_CAL_3        =     "63"
+
+            HITOR_MASK_0             =  "65535"
+            HITOR_MASK_1             =  "65535"
+            HITOR_MASK_2             =  "65535"
+            HITOR_MASK_3             =     "63"
+
+            PrecisionToTEnable_0     =      "0"
+            PrecisionToTEnable_1     =      "0"
+            PrecisionToTEnable_2     =      "0"
+            PrecisionToTEnable_3     =      "0"
+
+            EnHitsRemoval_0          =      "0"
+            EnHitsRemoval_1          =      "0"
+            EnHitsRemoval_2          =      "0"
+            EnHitsRemoval_3          =      "0"
+
+            EnIsolatedHitRemoval_0   =      "0"
+            EnIsolatedHitRemoval_1   =      "0"
+            EnIsolatedHitRemoval_2   =      "0"
+            EnIsolatedHitRemoval_3   =      "0"
+
+            HIT_SAMPLE_MODE          =      "1"
+            EN_SEU_COUNT             =      "0"
+            CDR_CONFIG_SEL_PD        =      "0"
+
+            LOCKLOSS_CNT             =      "0"
+            BITFLIP_WNG_CNT          =      "0"
+            BITFLIP_ERR_CNT          =      "0"
+            CMDERR_CNT               =      "0"
+            SKIPPED_TRIGGER_CNT      =      "0"
+            HITOR_0_CNT              =      "0"
+            HITOR_1_CNT              =      "0"
+            HITOR_2_CNT              =      "0"
+            HITOR_3_CNT              =      "0"
+
+            HitOrPatternLUT          = "0xFFFE"
+
+            READTRIG_CNT             =      "0"
+            RDWRFIFOERROR_CNT        =      "0"
+            PIXELSEU_CNT             =      "0"
+            GLOBALCONFIGSEU_CNT      =      "0"
+            />
+      </Hybrid>
+    </OpticalGroup>
+
+    <!-- Configuration for backend readout board -->
+    <Register name="user">
+      <Register name="ctrl_regs">
+
+        <Register name="fast_cmd_reg_2">
+          <Register name="trigger_source"> 2 </Register>
+          <!-- 1=IPBus, 2=Test-FSM, 3=TTC, 4=TLU, 5=External, 6=Hit-Or, 7=User-defined frequency -->
+          <Register name="HitOr_enable_l12"> 0 </Register>
+          <!-- HitOr port enable: set trigger_source to proper value then this register,
+               0b01 enables HitOr for the first (left-most) miniDP connector,
+               0b10 enables HitOr for the second miniDP connector, ...
+          -->
+        </Register>
+
+        <Register name="ext_tlu_reg1">
+          <Register name="dio5_ch1_thr"> 128 </Register>
+          <Register name="dio5_ch2_thr">  40 </Register>
+        </Register>
+
+        <Register name="ext_tlu_reg2">
+          <Register name="dio5_ch3_thr"> 128 </Register>
+          <Register name="dio5_ch4_thr"> 128 </Register>
+          <Register name="dio5_ch5_thr"> 128 </Register>
+
+          <Register name="tlu_delay"> 0 </Register>
+          <!-- Delay for TLU trigger ID -->
+        </Register>
+
+        <Register name="reset_reg">
+          <Register name="ext_clk_en"> 0 </Register>
+        </Register>
+
+        <Register name="fast_cmd_reg_3">
+          <Register name="triggers_to_accept"> 10 </Register>
+        </Register>
+
+        <Register name="fast_cmd_reg_7">
+          <Register name="autozero_freq"> 1000 </Register>
+          <!-- In units of 10MHz clk cyles -->
+        </Register>
+
+        <Register name="Aurora_block">
+          <Register name="self_trigger_en"> 0 </Register>
+        </Register>
+
+      </Register>
+    </Register>
+
+  </BeBoard>
+
+  <Settings>
+    <!-- === Calibration parameters ===
+         INJtype:
+            INJtype            = 0:  no injection
+            INJtype            = 1:  analog
+            INJtype            = 2:  digital
+            INJtype            = 3:  readout chip self-trigger
+            INJtype            = 4:  analog + custom from txt file
+            INJtype            = 5:  analog + X-talk coupled pixels
+            INJtype            = 6:  analog + X-talk decoupled pixels
+         ResetMask             = 0:  do not enable masked pixels;        ResetMask             = 1: enable all pixels
+         ResetTDAC             = -1: do not reset TDAC;                  ResetTDAC             >=0: reset all TDACs to value
+         DoDataIntegrity       = 0:  no data integrity detection;        DoDataIntegrity       = 1: run data integrity detection
+         DoOnlyNGroups         = 0:  do not consider this option;        DoOnlyNGroups         = n: run only on the specified number of groups
+         DisplayHisto          = 0:  don't display;                      DisplayHisto          = 1: display
+         UpdateChipCfg         = 0:  don't update;                       UpdateChipCfg         = 1: update
+         DisableChannelsAtExit = 0:  don't disable all channels at exit  DisableChannelsAtExit = 1: disable all channels at exit
+
+         DoNSteps        (threqu):           if != 0 then run threqu with step of 1 for only DoNSteps times
+         TargetCharge    (thradj):           average charge (electrons) corresponding to ToT point = max value - 1
+         TargetOcc       (thrmin):           average pixel occupancy
+         MaxMaskedPixels (thrmin):           percentage of masked pixels
+         OccPerPixel     (pixelalive,noise): per pixel occupancy threshold below/above which pixels are masked
+         UnstuckPixels   (pixelalive) = 0: do not try to unstuck pixels; UnstuckPixels = 1: set TDAC to 0 to unstuck pixels
+         chain2Test      (bertest,datarbopt) = 0: BE-FE; chain2Test = 1: BE-LPGBT; chain2Test = 2: LPGBT-FE
+         byTime          (bertest,datarbopt) = 0: give n. frames; byTime = 1: give time in [s]
+         framesORtime    (bertest,datarbopt):time in [s] or number of frames
+    -->
+    <Setting name="nEvents">             100 </Setting>
+    <Setting name="nEvtsBurst">          100 </Setting>
+    <!-- For Noise and Threshold Minimization
+    <Setting name="nEvents">         1000000 </Setting>
+    <Setting name="nEvtsBurst">        10000 </Setting>
+    -->
+
+    <Setting name="nTRIGxEvent">          10 </Setting>
+    <Setting name="INJtype">               1 </Setting>
+    <Setting name="ResetMask">             0 </Setting>
+    <Setting name="ResetTDAC">            -1 </Setting>
+    <Setting name="DoDataIntegrity">       0 </Setting>
+
+    <Setting name="ROWstart">              0 </Setting>
+    <Setting name="ROWstop">             335 </Setting>
+    <Setting name="COLstart">              0 </Setting>
+    <Setting name="COLstop">             431 </Setting>
+
+    <Setting name="LatencyStart">          0 </Setting>
+    <Setting name="LatencyStop">         511 </Setting>
+
+    <Setting name="VCalHstart">          100 </Setting>
+    <Setting name="VCalHstop">          1100 </Setting>
+    <Setting name="VCalHnsteps">          50 </Setting>
+    <Setting name="VCalMED">             100 </Setting>
+
+    <Setting name="TargetCharge">      10000 </Setting>
+    <Setting name="KrumCurrStart">         0 </Setting>
+    <Setting name="KrumCurrStop">        210 </Setting>
+
+    <Setting name="TDACGainStart">       140 </Setting>
+    <Setting name="TDACGainStop">        140 </Setting>
+    <Setting name="TDACGainNSteps">        0 </Setting>
+    <Setting name="DoNSteps">              0 </Setting>
+
+    <Setting name="ThrStart">            400 </Setting>
+    <Setting name="ThrStop">             450 </Setting>
+    <Setting name="TargetThr">          2000 </Setting>
+    <Setting name="TargetOcc">          1e-6 </Setting>
+    <Setting name="OccPerPixel">        2e-5 </Setting>
+    <Setting name="MaxMaskedPixels">       1 </Setting>
+    <Setting name="UnstuckPixels">         0 </Setting>
+
+    <Setting name="VDDDTrimTarget">     1.20 </Setting>
+    <Setting name="VDDATrimTarget">     1.20 </Setting>
+    <Setting name="VDDDTrimTolerance">  0.02 </Setting>
+    <Setting name="VDDATrimTolerance">  0.02 </Setting>
+
+    <Setting name="TAP0Start">             0 </Setting>
+    <Setting name="TAP0Stop">           1023 </Setting>
+    <Setting name="TAP1Start">             0 </Setting>
+    <Setting name="TAP1Stop">            511 </Setting>
+    <Setting name="InvTAP1">               1 </Setting>
+    <Setting name="TAP2Start">             0 </Setting>
+    <Setting name="TAP2Stop">            511 </Setting>
+    <Setting name="InvTAP2">               0 </Setting>
+
+    <Setting name="chain2Test">            0 </Setting>
+    <Setting name="byTime">                1 </Setting>
+    <Setting name="framesORtime">         10 </Setting>
+
+    <Setting name="TargetBER">          1e-5 </Setting>
+
+    <Setting name="RegNameDAC1"> user.ctrl_regs.fast_cmd_reg_5.delay_after_inject_pulse </Setting>
+    <Setting name="StartValueDAC1">       28 </Setting>
+    <Setting name="StopValueDAC1">        50 </Setting>
+    <Setting name="StepDAC1">              1 </Setting>
+    <Setting name="RegNameDAC2">   VCAL_HIGH </Setting>
+    <Setting name="StartValueDAC2">      300 </Setting>
+    <Setting name="StopValueDAC2">      1000 </Setting>
+    <Setting name="StepDAC2">             20 </Setting>
+
+    <Setting name="DoOnlyNGroups">         0 </Setting>
+    <Setting name="DisplayHisto">          0 </Setting>
+    <Setting name="UpdateChipCfg">         1 </Setting>
+    <Setting name="DisableChannelsAtExit"> 1 </Setting>
+
+    <!-- === Expert settings ===
+         DataOutputDir:   set the output directory for all data. If not specified files will be saved in ./Results/
+         SaveBinaryData = 0: do not save raw data in binary format; SaveBinaryData = 1: save raw data in binary format
+         nHITxCol:        number of simultaneously injected pixels per column (it must be a divider of chip rows)
+         InjLatency:      controls the latency of the injection in terms of 100ns period (up to 4095)
+         nClkDelays:      controls the delay between two consecutive injections in terms of 100ns period (up to 4095)
+    -->
+    <Setting name="DataOutputDir">           </Setting>
+    <Setting name="SaveBinaryData">        0 </Setting>
+    <Setting name="nHITxCol">              1 </Setting>
+    <Setting name="InjLatency">           32 </Setting>
+    <Setting name="nClkDelays">         1300 </Setting>
+  </Settings>
+
+  <!-- === Monitoring parameters ===
+       MonitoringSleepTime: sleep for monitoring thread in milliseconds
+  -->
+  <MonitoringSettings>
+    <Monitoring type="RD53B" enable="0">
+      <MonitoringSleepTime> 1000 </MonitoringSleepTime>
+      <MonitoringElement device="RD53"  register="VINA"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="VDDA"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="ANA_IN_CURR"          enable="1"/>
+      <MonitoringElement device="RD53"  register="VIND"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="VDDD"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="DIG_IN_CURR"          enable="1"/>
+      <MonitoringElement device="RD53"  register="Iref"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="POLY_TEMPSENS_TOP"    enable="1"/>
+      <MonitoringElement device="RD53"  register="POLY_TEMPSENS_BOTTOM" enable="1"/>
+      <MonitoringElement device="RD53"  register="TEMPSENS_ANA_SLDO"    enable="1"/>
+      <MonitoringElement device="RD53"  register="TEMPSENS_DIG_SLDO"    enable="1"/>
+      <MonitoringElement device="RD53"  register="TEMPSENS_CENTER"      enable="1"/>
+      <MonitoringElement device="RD53"  register="INTERNAL_NTC"         enable="1"/>
+
+      <MonitoringElement device="LpGBT" register="TEMP"                 enable="0"/>
+      <MonitoringElement device="LpGBT" register="VDD"                  enable="0"/>
+      <MonitoringElement device="LpGBT" register="PUSMStatus"           enable="0"/>
+    </Monitoring>
+  </MonitoringSettings>
+
+<!-- === Communication parameters === -->
+<CommunicationSettings>
+    <DQM               ip="127.0.0.1" port="6000" enableConnection="0"/>
+    <MonitorDQM        ip="127.0.0.1" port="8000" enableConnection="0"/>
+    <PowerSupplyClient ip="127.0.0.1" port="7000" enableConnection="0"/>
+</CommunicationSettings>
+
+</HwDescription>


### PR DESCRIPTION
Updates from 2023

Operating digital modules with Ph2_ACF
- Update digital module instructions: use new working area for optical readout; electrical readout is not yet tested and updated for the new working area.
- Document port card power settings; should reorganize since this is used for both digital module and SCC testing.
- Document digital module power settings for constant current mode

Testing Type 5K e-links
- Still debugging latest Ph2_ACF software and FC7 firmware; did not work during testing in December 2023: Ph2_ACF v4-18, FC7 FW v4.8
- Need to revert to previous working Ph2_ACF software and FC7 firmware versions: Ph2_ACF v4-13, FC7 FW v4.5