### PR TITLE
Type 5K e-links settings and whitespace bug fix for search/replace TAP0 setting

### DIFF
--- a/python/BERT_Plot.py
+++ b/python/BERT_Plot.py
@@ -7,8 +7,8 @@ from tools import makeDir
 # FIXME: Should set x and y labels when calling plot() instead of changing defaults.
 
 # Change y-axis label based on BERT; bits/frams and time
-#def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Bit errors over 20 seconds", setLogY=True, y_errors=[]):
-def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Frame errors over 10 seconds", setLogY=True, y_errors=[]):
+#def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Frame errors over 10 seconds", setLogY=True, y_errors=[]):
+def plot(plot_dir, output_file, x_values, y_values, x_label="TAP0 DAC", y_label="Bit errors over 20 seconds", setLogY=True, y_errors=[]):
     useXKCDStyle = False    # Use XKCD style
     setAxisLimits = False   # Use assigned axis limits
 

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -9,6 +9,11 @@ def getDefaultInputs(cable_number, channel):
     # Default input parameters
     inputs      = {}
     
+    # Micro TAP0 range
+    tap0_min    = 10
+    tap0_max    = 30
+    tap0_step   = 1
+
     # Mini TAP0 range
     #tap0_min    = 20
     #tap0_max    = 100
@@ -25,9 +30,9 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Large TAP0 range
-    tap0_min    = 100
-    tap0_max    = 1000
-    tap0_step   = 100
+    #tap0_min    = 100
+    #tap0_max    = 1000
+    #tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!

--- a/python/BERT_Scan.py
+++ b/python/BERT_Scan.py
@@ -15,9 +15,9 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Small TAP0 range
-    tap0_min    = 50
-    tap0_max    = 150
-    tap0_step   = 10
+    #tap0_min    = 50
+    #tap0_max    = 150
+    #tap0_step   = 10
     
     # Medium TAP0 range
     #tap0_min    = 100
@@ -25,9 +25,9 @@ def getDefaultInputs(cable_number, channel):
     #tap0_step   = 10
     
     # Large TAP0 range
-    #tap0_min    = 100
-    #tap0_max    = 1000
-    #tap0_step   = 100
+    tap0_min    = 100
+    tap0_max    = 1000
+    tap0_step   = 100
     
     signal      = 0     # Type of secondary signal; use 0 as default.
     TAP1        = 0     # See note below about setting TAP1!!!
@@ -60,12 +60,12 @@ def getDefaultInputs(cable_number, channel):
     
     # RD53B + port card with e-link in J4:
     #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_SMA_Adapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
-    #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+    output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
 
     # Module + port card with e-link in J4:
     #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
     #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip12/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
-    output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip13/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
+    #output_dir  = "BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip13/elink{0}_{1}_SS{2}_TAP1_{3}".format(cable_number, channel, signal, TAP1)
 
     inputs["tap0_min"]      = tap0_min
     inputs["tap0_max"]      = tap0_max

--- a/python/BERT_Simple_Analyze.py
+++ b/python/BERT_Simple_Analyze.py
@@ -216,9 +216,9 @@ def analyzeScansRD53B(cable_number):
     #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     # using port card with e-link in J4 with red adapter board:
-    #base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
-    #base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
-    #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
+    base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_DP_RedAdapter"
+    output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     # using port card with e-link in J4 with module:
     #base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module"
@@ -231,9 +231,9 @@ def analyzeScansRD53B(cable_number):
     #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     # using port card with e-link in J4 with module, chip 13:
-    base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip13"
-    base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip13"
-    output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
+    #base_plot_dir    = "plots/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip13"
+    #base_data_dir    = "data/BERT_TAP0_Scans/Optical_FMC_PortCard_J4_Module_Chip13"
+    #output_csv_name  = "output/BERT_Min_TAP0_Values.csv"
     
     #base_plot_dir    = "plots/BERT_TAP0_Scans/SingleDP"
     #base_data_dir    = "data/BERT_TAP0_Scans/SingleDP"

--- a/scripts/PortCard_BERT_Scan.sh
+++ b/scripts/PortCard_BERT_Scan.sh
@@ -47,13 +47,12 @@ mkdir -p "$dataDir"
 
 cp CMSIT_RD53B_Optical_BERT.xml CMSIT_RD53B_Optical_BERT_Custom.xml
 
-# FIXME: We should find a better way to do this that does not break based on the number of spaces!!
-
-# WARNING
-# Be careful about the number of spaces;
-# must match the line in the xml file for search/replace to work!!!
-sed -i -e "s|DAC_CML_BIAS_0         =   \"500\"|DAC_CML_BIAS_0         =   \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
-#sed -i -e "s|DAC_CML_BIAS_0         =    \"500\"|DAC_CML_BIAS_0         =    \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
+# Updated sed command (credit: ChatGPT 3.5):
+# - the -E option enables extended regular expressions to make the syntax simpler
+# - the -i is for editing the file in place
+# - should match zero or more whitespace characters (space, tab, or newline) around the equal sign
+# - after replacement, it should maintain the same whitespace as the original line
+sed -E -i "s/(DAC_CML_BIAS_0\s*=\s*)\"[0-9]+\"/\1\"$TAP0_Setting\"/" CMSIT_RD53B_Optical_BERT_Custom.xml
 
 # Run BERT and send output to file
 echo "Running BERT with TAP0=$TAP0_Setting" | tee -a $outFile

--- a/scripts/PortCard_BERT_Scan.sh
+++ b/scripts/PortCard_BERT_Scan.sh
@@ -52,8 +52,8 @@ cp CMSIT_RD53B_Optical_BERT.xml CMSIT_RD53B_Optical_BERT_Custom.xml
 # WARNING
 # Be careful about the number of spaces;
 # must match the line in the xml file for search/replace to work!!!
-#sed -i -e "s|DAC_CML_BIAS_0         =   \"500\"|DAC_CML_BIAS_0         =   \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
-sed -i -e "s|DAC_CML_BIAS_0         =    \"500\"|DAC_CML_BIAS_0         =    \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
+sed -i -e "s|DAC_CML_BIAS_0         =   \"500\"|DAC_CML_BIAS_0         =   \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
+#sed -i -e "s|DAC_CML_BIAS_0         =    \"500\"|DAC_CML_BIAS_0         =    \""${TAP0_Setting}"\"|g" CMSIT_RD53B_Optical_BERT_Custom.xml
 
 # Run BERT and send output to file
 echo "Running BERT with TAP0=$TAP0_Setting" | tee -a $outFile


### PR DESCRIPTION
Changes
- Switch paths for Type 5K e-link setup
- Fix bug in sed command to search and replace DAC_CML_BIAS_0 setting: support zero or more whitespaces!

For the whitespace bug fix, see the issue here: https://github.com/ku-cms/TrackerDAQ/issues/20
