### PR TITLE
Updates for kucms-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ cd ..
 ```
 
 Setup a Ph2_ACF working area and copy the required files.
-choose a directory name (using DAQSettings_v1 for this example):
+Choose a directory name (using DAQSettings_v1 for this example):
 ```
 mkdir -p DAQSettings_v1
 cp settings/RD53Files/CMSIT*.txt DAQSettings_v1
 cp settings/CMSIT*.xml DAQSettings_v1
-cp settings/lpGBTFiles/CMSIT_LpGBT-v1.txt DAQSettings_v1
+cp settings/lpGBTFiles/CMSIT*.txt DAQSettings_v1
 cd DAQSettings_v1
 ```
 

--- a/docs/CROC_SCC_commands.txt
+++ b/docs/CROC_SCC_commands.txt
@@ -1,0 +1,50 @@
+CROC Single Chip Card (SCC) with 3D sensor
+
+Setup commands:
+cd /home/kucms/TrackerDAQ/modules/Ph2_ACF
+source setup.sh
+cd DAQSettings_v1
+fpgaconfig -c CMSIT_RD53B_Electrical.xml -i IT-L12-KSU-L8-KSU_CROC_v4p8
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -r
+
+Try these after firmware is loaded and module powered on:
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c bertest
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c physics
+
+Data taking:
+
+Turn on LV and HV.
+
+LV: 1.60 V, 2.00 A on left and right
+
+HV: -1.0 V (-40 micro amps), -2.0 V (-100 micro amps)
+
+Use the multimeter and python script to measure the temperature:
+python3 python/measureTemperature.py
+
+The normal temperature is 18 C.
+
+Copy text file to start with the default values:
+
+cp CMSIT_RD53B_default.txt CMSIT_RD53B.txt
+
+Set "TargetThr" in the xml file CMSIT_RD53B_Electrical.xml:
+The default is 2000; we should try 1200.
+
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c thradj
+-- manually edit xml: global threshold (GDAC values)
+
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c threqu
+-- automatically updates text file: per pixel threshold
+
+Run "physics" without and with x-rays for the same amount of time.
+You need to time this!
+Start and stop with enter.
+May take up to 15 minutes to stop after pressing enter.
+
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c physics
+
+
+
+

--- a/docs/CROC_SCC_commands.txt
+++ b/docs/CROC_SCC_commands.txt
@@ -1,14 +1,27 @@
 CROC Single Chip Card (SCC) with 3D sensor
 
-Setup commands:
+Setup commands on kucms:
+
 cd /home/kucms/TrackerDAQ/modules/Ph2_ACF
 source setup.sh
 cd DAQSettings_v1
 fpgaconfig -c CMSIT_RD53B_Electrical.xml -i IT-L12-KSU-L8-KSU_CROC_v4p8
 CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -r
 
+Setup commands on kucms-02:
+
+cd /home/kucms/TrackerDAQ/module_testing_v1/Ph2_ACF
+source setup.sh
+cd DAQSettings_v1
+fpgaconfig -c CMSIT_RD53B_Electrical.xml -i IT-L12-KSU-L8-KSU_CROC_v4p9
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -r
+
 Try these after firmware is loaded and module powered on:
+
 CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -p
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c pixelalive
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c noise
+CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c scurve
 CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c bertest
 CMSITminiDAQ -f CMSIT_RD53B_Electrical.xml -c physics
 

--- a/docs/commands_v3.txt
+++ b/docs/commands_v3.txt
@@ -72,6 +72,15 @@ fpgaconfig -c CMSIT_RD53B_Optical.xml -l
 fpgaconfig -c CMSIT_RD53B_Optical.xml -f IT-uDTC_L8-OPTO-4xSCC_OPTICAL_CROC_v4.5.bit -i IT-L8-OPTO_CROC_v4p5
 fpgaconfig -c CMSIT_RD53B_Optical.xml -l
 
+fpgaconfig -c CMSIT_RD53B_Optical.xml -l
+fpgaconfig -c CMSIT_RD53B_Optical.xml -f FC7_firmware/RD53B_CROC/IT-uDTC_L8-OPTO-4xSCC_OPTICAL_CROC_v4.9.bit -i IT-L8-OPTO_CROC_v4p9
+fpgaconfig -c CMSIT_RD53B_Optical.xml -l
+
+RD53B electrical readout:
+fpgaconfig -c CMSIT_RD53B_Electrical.xml -l
+fpgaconfig -c CMSIT_RD53B_Electrical.xml -f FC7_firmware/RD53B_CROC/IT-uDTC_L12-KSU-4xSCC_L8-KSU-4xSCC_ELECTRICAL_CROC_v4.9.bit -i IT-L12-KSU-L8-KSU_CROC_v4p9
+fpgaconfig -c CMSIT_RD53B_Electrical.xml -l
+
 RD53A quad module electrical readout:
 fpgaconfig -c CMSIT_RD53A_Electrical.xml -l
 fpgaconfig -c CMSIT_RD53A_Electrical.xml -f IT-uDTC_L12-KSU-3xQUAD_L8-DIO5_ELECTRICAL_RD53A_v4.5.bit -i IT-L12-KSU-RD53A_QUAD_v4p5

--- a/docs/pyroot_instructions.txt
+++ b/docs/pyroot_instructions.txt
@@ -1,3 +1,9 @@
+------------------------------
+Using PyROOT (ROOT + Python 3)
+------------------------------
+
+------------------------------------------------
+
 Instructions from Alan Feltz (February 20, 2024):
 
 ROOT version installed to use PyROOT:
@@ -12,6 +18,31 @@ If you want to use use root within python or python within root, you will need t
 
 export PYTHONPATH=/usr/local/root-6.30.04/lib
 export LD_LIBRARY_PATH=/usr/local/root-6.30.04/lib
-root
+
+python3
+import ROOT
+
+------------------------------------------------
+
+Update from Caleb Smith (August 29, 2024):
+
+First, tested adding the export commands to ~/.bash_profile
+so that users can use ROOT + Python 3 by default when logging in.
+
+However, Derek reported that this breaks Ph2_ACF commands, which is somewhat expected.
+
+I created this script to set up PyROOT (ROOT + Python 3) environment:
+
+/home/kucms/bin/setup_pyroot.sh
+
+Run using either of the following commands:
+
+source setup_pyroot.sh 
+
+. setup_pyroot.sh
+
+Important: source or . are required to set environment variables in your terminal session!
+
+------------------------------------------------
 
 

--- a/settings/CMSIT_RD53B_Electrical_Ph2_ACF_v4_18.xml
+++ b/settings/CMSIT_RD53B_Electrical_Ph2_ACF_v4_18.xml
@@ -250,7 +250,7 @@
     <Setting name="ThrStart">            400 </Setting>
     <Setting name="ThrStop">             450 </Setting>
     <Setting name="TargetThr">          2000 </Setting>
-    <Setting name="TargetOcc">          1e-6 </Setting>
+    <Setting name="TargetOcc">          1e-4 </Setting>
     <Setting name="OccPerPixel">        2e-5 </Setting>
     <Setting name="MaxMaskedPixels">       1 </Setting>
     <Setting name="UnstuckPixels">         0 </Setting>
@@ -300,7 +300,7 @@
     <Setting name="SaveBinaryData">        0 </Setting>
     <Setting name="nHITxCol">              1 </Setting>
     <Setting name="InjLatency">           32 </Setting>
-    <Setting name="nClkDelays">         1300 </Setting>
+    <Setting name="nClkDelays">         4000 </Setting>
   </Settings>
 
   <!-- === Monitoring parameters ===

--- a/settings/CMSIT_RD53B_Electrical_Ph2_ACF_v5_04.xml
+++ b/settings/CMSIT_RD53B_Electrical_Ph2_ACF_v5_04.xml
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<HwDescription>
+  <BeBoard Id="0" boardType="RD53" eventType="VR" configure="1" comment="">
+    <connection id="nanocrate" uri="ipbusudp-2.0://192.168.1.100:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
+    <!---
+        <connection id="cmsinnertracker.crate0.slot0" uri="ipbusudp-2.0://fc7-1:50001" address_table="file://${PH2ACF_BASE_DIR}/settings/address_tables/CMSIT_address_table.xml" />
+    -->
+
+    <!-- Frontend chip configuration -->
+    <OpticalGroup Id="0" enable="1" FMCId="L12">
+      <!--
+      <lpGBT_Files path="${PWD}" />
+      <lpGBT_ConfigFile fileName="${PH2ACF_BASE_DIR}/settings/lpGBTFiles/lpgbt_calibration.csv" />
+      <lpGBT Id="0" version="0" configFile="CMSIT_LpGBTv0.txt" ChipAddress="0x70" RxDataRate="1280" RxHSLPolarity="1" TxDataRate="160" TxHSLPolarity="0">
+      -->
+      <!-- Put here any LpGBT register, if needed
+            EPRX60ChnCntr_phase = "6" -->
+      <!--
+        <Settings
+            />
+      </lpGBT>
+      -->
+      <Hybrid Id="0" enable="1">
+        <RD53_Files path="${PWD}/" />
+
+        <!-- Available Comment fields are: 50x50, 25x100origR0C0, 25x100origR1C0, unknown, combined with RD53A, RD53B, dual, quad -->
+        <RD53Bv2 Id="15" enable="1" Lane="0" eFuseCode = "0" configFile="CMSIT_RD53Bv2.txt" RxGroups="0006" RxPolarity="0" TxGroup="3" TxChannel="0" TxPolarity="0" Comment="RD53B 50x50">
+          <LaneConfig isPrimary="1" masterLane="0" outputLanes="0001" singleChannelInputs="0000" dualChannelInput="0000" />
+          <!-- Overwrite .txt configuration file settings -->
+          <Settings
+              DAC_PREAMP_L_LIN       =    "300"
+              DAC_PREAMP_R_LIN       =    "300"
+              DAC_PREAMP_TL_LIN      =    "300"
+              DAC_PREAMP_TR_LIN      =    "300"
+              DAC_PREAMP_T_LIN       =    "300"
+              DAC_PREAMP_M_LIN       =    "300"
+              DAC_FC_LIN             =     "20"
+              DAC_KRUM_CURR_LIN      =     "70"
+              DAC_REF_KRUM_LIN       =    "360"
+              DAC_COMP_LIN           =    "110"
+              DAC_COMP_TA_LIN        =    "110"
+              DAC_GDAC_L_LIN         =    "450"
+              DAC_GDAC_R_LIN         =    "450"
+              DAC_GDAC_M_LIN         =    "450"
+              DAC_LDAC_LIN           =    "140"
+
+              VCAL_HIGH              =   "2000"
+              VCAL_MED               =    "100"
+
+              GP_LVDS_ROUTE_0        =   "1495"
+              GP_LVDS_ROUTE_1        =   "1495"
+              TriggerConfig          =    "136"
+              CLK_DATA_DELAY         =      "0"
+              CAL_EDGE_FINE_DELAY    =      "0"
+              ANALOG_INJ_MODE        =      "0"
+              SEL_CAL_RANGE          =      "0"
+
+              SelfTriggerEn          =      "0"
+              SelfTriggerDelay       =     "30"
+              EnOutputDataChipId     =      "1"
+
+              VOLTAGE_TRIM_DIG       =      "8"
+              VOLTAGE_TRIM_ANA       =      "8"
+
+              CML_CONFIG_SER_EN_TAP  =   "0b00"
+              CML_CONFIG_SER_INV_TAP =   "0b00"
+              DAC_CML_BIAS_0         =    "500"
+              DAC_CML_BIAS_1         =      "0"
+              DAC_CML_BIAS_2         =      "0"
+
+              MON_ADC_TRIM           =      "5"
+
+              ToT6to4Mapping         =      "0"
+              ToTDualEdgeCount       =      "0"
+
+              RESISTORI2V            =   "5000"
+              ADC_OFFSET_VOLT        =     "63"
+              ADC_MAXIMUM_VOLT       =    "839"
+              TEMPSENS_IDEAL_FACTOR  =   "1225"
+              SAMPLE_N_TIMES         =     "10"
+              WAIT_MUX_CONFIG        =    "100"
+              VREF_ADC               =    "800"
+              />
+        </RD53Bv2>
+
+        <Global
+            EN_CORE_COL_0            =  "65535"
+            EN_CORE_COL_1            =  "65535"
+            EN_CORE_COL_2            =  "65535"
+            EN_CORE_COL_3            =     "63"
+
+            EN_CORE_COL_CAL_0        =  "65535"
+            EN_CORE_COL_CAL_1        =  "65535"
+            EN_CORE_COL_CAL_2        =  "65535"
+            EN_CORE_COL_CAL_3        =     "63"
+
+            HITOR_MASK_0             =  "65535"
+            HITOR_MASK_1             =  "65535"
+            HITOR_MASK_2             =  "65535"
+            HITOR_MASK_3             =     "63"
+
+            PrecisionToTEnable_0     =      "0"
+            PrecisionToTEnable_1     =      "0"
+            PrecisionToTEnable_2     =      "0"
+            PrecisionToTEnable_3     =      "0"
+
+            EnHitsRemoval_0          =      "0"
+            EnHitsRemoval_1          =      "0"
+            EnHitsRemoval_2          =      "0"
+            EnHitsRemoval_3          =      "0"
+
+            EnIsolatedHitRemoval_0   =      "0"
+            EnIsolatedHitRemoval_1   =      "0"
+            EnIsolatedHitRemoval_2   =      "0"
+            EnIsolatedHitRemoval_3   =      "0"
+
+            HIT_SAMPLE_MODE          =      "1"
+            EN_SEU_COUNT             =      "0"
+            CDR_CONFIG_SEL_PD        =      "0"
+
+            LOCKLOSS_CNT             =      "0"
+            BITFLIP_WNG_CNT          =      "0"
+            BITFLIP_ERR_CNT          =      "0"
+            CMDERR_CNT               =      "0"
+            SKIPPED_TRIGGER_CNT      =      "0"
+            HITOR_0_CNT              =      "0"
+            HITOR_1_CNT              =      "0"
+            HITOR_2_CNT              =      "0"
+            HITOR_3_CNT              =      "0"
+
+            HitOrPatternLUT          = "0xFFFE"
+
+            READTRIG_CNT             =      "0"
+            RDWRFIFOERROR_CNT        =      "0"
+            PIXELSEU_CNT             =      "0"
+            GLOBALCONFIGSEU_CNT      =      "0"
+            />
+      </Hybrid>
+    </OpticalGroup>
+
+    <!-- Configuration for backend readout board -->
+    <Register name="user">
+      <Register name="ctrl_regs">
+
+        <Register name="fast_cmd_reg_2">
+          <Register name="trigger_source"> 2 </Register>
+          <!-- 1=IPBus, 2=Test-FSM, 3=TTC, 4=TLU, 5=External, 6=Hit-Or, 7=User-defined frequency -->
+          <Register name="HitOr_enable_l12"> 0 </Register>
+          <!-- HitOr port enable: set trigger_source to proper value then this register,
+               0b01 enables HitOr for the first (left-most) miniDP connector,
+               0b10 enables HitOr for the second miniDP connector, ...
+          -->
+        </Register>
+
+        <Register name="ext_tlu_reg1">
+          <Register name="dio5_ch1_thr"> 128 </Register>
+          <Register name="dio5_ch2_thr">  40 </Register>
+        </Register>
+
+        <Register name="ext_tlu_reg2">
+          <Register name="dio5_ch3_thr"> 128 </Register>
+          <Register name="dio5_ch4_thr"> 128 </Register>
+          <Register name="dio5_ch5_thr"> 128 </Register>
+
+          <Register name="tlu_delay"> 0 </Register>
+          <!-- Delay for TLU trigger ID -->
+        </Register>
+
+        <Register name="reset_reg">
+          <Register name="nb_of_pll_words"> 2 </Register>
+          <Register name="nb_of_sync_words"> 2 </Register>
+          <Register name="ext_clk_en"> 0 </Register>
+        </Register>
+
+        <Register name="fast_cmd_reg_3">
+          <Register name="triggers_to_accept"> 10 </Register>
+        </Register>
+
+        <Register name="fast_cmd_reg_7">
+          <Register name="autozero_freq"> 1000 </Register>
+          <!-- In units of 10MHz clk cyles -->
+        </Register>
+
+        <Register name="Aurora_block">
+          <Register name="self_trigger_en"> 0 </Register>
+        </Register>
+
+        <Register name="cnf_cmd_ctrl">
+          <Register name="nb_slow_cmd_before_sync"> 0 </Register>
+          <Register name="nb_slow_cmd_before_pll"> 0 </Register>
+        </Register>
+
+      </Register>
+    </Register>
+
+  </BeBoard>
+
+  <Settings>
+    <!-- === Calibration parameters ===
+         INJtype:
+            INJtype            = 0:  no injection
+            INJtype            = 1:  analog
+            INJtype            = 2:  digital
+            INJtype            = 3:  readout chip self-trigger
+            INJtype            = 4:  analog + custom from txt file
+            INJtype            = 5:  analog + X-talk coupled pixels
+            INJtype            = 6:  analog + X-talk decoupled pixels
+         ResetMask             = 0:  do not enable masked pixels;             ResetMask             = 1: enable all pixels
+         ResetTDAC             = -1: do not reset TDAC;                       ResetTDAC             >=0: reset all TDACs to value
+         DoDataIntegrity       = 0:  no data integrity detection;             DoDataIntegrity       = 1: run data integrity detection at core-colum level;
+                                                                              DoDataIntegrity       = 2: run data integrity detection at pixel level;
+                                                                              DoDataIntegrity       = 3: run data integrity detection at pixel level but masks whole core
+         DoOnlyNGroups         = 0:  do not consider this option;             DoOnlyNGroups         = n: run only on the specified number of groups
+         DisplayHisto          = 0:  don't display;                           DisplayHisto          = 1: display
+         UpdateChipCfg         = 0:  don't update;                            UpdateChipCfg         = 1: update
+         DisableChannelsAtExit = 0:  don't disable all channels at exit       DisableChannelsAtExit = 1: disable all channels at exit
+         StopIfCommFails       = 0:  don't exit if some AURORA lanes are down StopIfCommFails       = 1: exit if some AURORA lanes are down
+
+         DoNSteps        (threqu):           if != 0 then run threqu with step of 1 for only DoNSteps times
+         TargetCharge    (thradj):           average charge (electrons) corresponding to ToT point = max value - 1
+         TargetOcc       (thrmin):           average pixel occupancy
+         MaxMaskedPixels (thrmin):           percentage of masked pixels
+         OccPerPixel     (pixelalive,noise): per pixel occupancy threshold below/above which pixels are masked
+         UnstuckPixels   (pixelalive) = 0: do not try to unstuck pixels; UnstuckPixels = 1: set TDAC to 0 to unstuck pixels
+         chain2Test      (bertest,datarbopt) = 0: BE-FE; chain2Test = 1: BE-LPGBT; chain2Test = 2: LPGBT-FE
+         byTime          (bertest,datarbopt) = 0: give n. frames; byTime = 1: give time in [s]
+         framesORtime    (bertest,datarbopt):time in [s] or number of frames
+    -->
+    <Setting name="nEvents">             100 </Setting>
+    <Setting name="nEvtsBurst">          100 </Setting>
+    <!-- For Noise and Threshold Minimization
+    <Setting name="nEvents">         1000000 </Setting>
+    <Setting name="nEvtsBurst">        10000 </Setting>
+    -->
+
+    <Setting name="nTRIGxEvent">          10 </Setting>
+    <Setting name="INJtype">               1 </Setting>
+    <Setting name="ResetMask">             0 </Setting>
+    <Setting name="ResetTDAC">            -1 </Setting>
+    <Setting name="DoDataIntegrity">       0 </Setting>
+
+    <Setting name="ROWstart">              0 </Setting>
+    <Setting name="ROWstop">             335 </Setting>
+    <Setting name="COLstart">              0 </Setting>
+    <Setting name="COLstop">             431 </Setting>
+
+    <Setting name="LatencyStart">          0 </Setting>
+    <Setting name="LatencyStop">         511 </Setting>
+
+    <Setting name="VCalHstart">          100 </Setting>
+    <Setting name="VCalHstop">          1100 </Setting>
+    <Setting name="VCalHnsteps">          50 </Setting>
+    <Setting name="VCalMED">             100 </Setting>
+
+    <Setting name="TargetCharge">      10000 </Setting>
+    <Setting name="KrumCurrStart">         0 </Setting>
+    <Setting name="KrumCurrStop">        210 </Setting>
+
+    <Setting name="TDACGainStart">       140 </Setting>
+    <Setting name="TDACGainStop">        140 </Setting>
+    <Setting name="TDACGainNSteps">        0 </Setting>
+    <Setting name="DoNSteps">              0 </Setting>
+
+    <Setting name="ThrStart">            400 </Setting>
+    <Setting name="ThrStop">             450 </Setting>
+    <Setting name="TargetThr">          2000 </Setting>
+    <Setting name="TargetOcc">          1e-6 </Setting>
+    <Setting name="OccPerPixel">        2e-5 </Setting>
+    <Setting name="MaxMaskedPixels">       1 </Setting>
+    <Setting name="UnstuckPixels">         0 </Setting>
+
+    <Setting name="VDDDTrimTarget">     1.20 </Setting>
+    <Setting name="VDDATrimTarget">     1.20 </Setting>
+    <Setting name="VDDDTrimTolerance">  0.02 </Setting>
+    <Setting name="VDDATrimTolerance">  0.02 </Setting>
+
+    <Setting name="TAP0Start">             0 </Setting>
+    <Setting name="TAP0Stop">           1023 </Setting>
+    <Setting name="TAP1Start">             0 </Setting>
+    <Setting name="TAP1Stop">            511 </Setting>
+    <Setting name="InvTAP1">               1 </Setting>
+    <Setting name="TAP2Start">             0 </Setting>
+    <Setting name="TAP2Stop">            511 </Setting>
+    <Setting name="InvTAP2">               0 </Setting>
+
+    <Setting name="chain2Test">            0 </Setting>
+    <Setting name="byTime">                1 </Setting>
+    <Setting name="framesORtime">         10 </Setting>
+
+    <Setting name="RegNameDAC1"> user.ctrl_regs.fast_cmd_reg_5.delay_after_inject_pulse </Setting>
+    <Setting name="StartValueDAC1">       28 </Setting>
+    <Setting name="StopValueDAC1">        50 </Setting>
+    <Setting name="StepDAC1">              1 </Setting>
+    <Setting name="RegNameDAC2">   VCAL_HIGH </Setting>
+    <Setting name="StartValueDAC2">      300 </Setting>
+    <Setting name="StopValueDAC2">      1000 </Setting>
+    <Setting name="StepDAC2">             20 </Setting>
+
+    <Setting name="DoOnlyNGroups">         0 </Setting>
+    <Setting name="DisplayHisto">          0 </Setting>
+    <Setting name="UpdateChipCfg">         1 </Setting>
+    <Setting name="DisableChannelsAtExit"> 1 </Setting>
+    <Setting name="StopIfCommFails">       1 </Setting>
+
+    <!-- === Expert settings ===
+         ShowRunProgress = 1: show run progress;         ShowRunProgress = 0: do not show run progress
+         DoSplitByHybrid = 1: split ROOT file by Hybrid; DoSplitByHybrid = 0: do not split ROOT file by Hybrid
+         DataOutputDir:    set the output directory for all data. If not specified files will be saved in ./Results/
+         SaveBinaryData  = 0: do not save raw data in binary format; SaveBinaryData = 1: save raw data in binary format
+         nHITxCol:         number of simultaneously injected pixels per column (it must be a divider of chip rows)
+         InjLatency:       controls the latency of the injection in terms of 100ns period (up to 4095)
+         nClkDelays:       controls the delay between two consecutive injections in terms of 100ns period (up to 4095)
+    -->
+    <Setting name="ShowRunProgress">       1 </Setting>
+    <Setting name="DoSplitByHybrid">       0 </Setting>
+    <Setting name="DataOutputDir">           </Setting>
+    <Setting name="SaveBinaryData">        0 </Setting>
+    <Setting name="nHITxCol">              1 </Setting>
+    <Setting name="InjLatency">           32 </Setting>
+    <Setting name="nClkDelays">         1300 </Setting>
+  </Settings>
+
+  <!-- === Monitoring parameters ===
+       MonitoringSleepTime: sleep for monitoring thread in milliseconds
+  -->
+  <MonitoringSettings>
+    <Monitoring type="RD53B" enable="0" silentRunning="0">
+      <MonitoringSleepTime> 1000 </MonitoringSleepTime>
+      <MonitoringElement device="RD53"  register="VINA"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="VDDA"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="ANA_IN_CURR"          enable="1"/>
+      <MonitoringElement device="RD53"  register="VIND"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="VDDD"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="DIG_IN_CURR"          enable="1"/>
+      <MonitoringElement device="RD53"  register="Iref"                 enable="1"/>
+      <MonitoringElement device="RD53"  register="POLY_TEMPSENS_TOP"    enable="1"/>
+      <MonitoringElement device="RD53"  register="POLY_TEMPSENS_BOTTOM" enable="1"/>
+      <MonitoringElement device="RD53"  register="TEMPSENS_ANA_SLDO"    enable="1"/>
+      <MonitoringElement device="RD53"  register="TEMPSENS_DIG_SLDO"    enable="1"/>
+      <MonitoringElement device="RD53"  register="TEMPSENS_CENTER"      enable="1"/>
+      <MonitoringElement device="RD53"  register="INTERNAL_NTC"         enable="1"/>
+
+      <MonitoringElement device="LpGBT" register="TEMP"                 enable="0"/>
+      <MonitoringElement device="LpGBT" register="VDDTX"                enable="0"/>
+      <MonitoringElement device="LpGBT" register="VDDRX"                enable="0"/>
+      <MonitoringElement device="LpGBT" register="VDDA"                 enable="0"/>
+      <MonitoringElement device="LpGBT" register="VDD"                  enable="0"/>
+      <MonitoringElement device="LpGBT" register="PUSMStatus"           enable="0"/>
+    </Monitoring>
+  </MonitoringSettings>
+
+<!-- === Communication parameters === -->
+<CommunicationSettings>
+    <DQM               ip="127.0.0.1" port="6000" enableConnection="0"/>
+    <MonitorDQM        ip="127.0.0.1" port="8000" enableConnection="0"/>
+    <PowerSupplyClient ip="127.0.0.1" port="7000" enableConnection="0"/>
+</CommunicationSettings>
+
+</HwDescription>


### PR DESCRIPTION
Updates for kucms-02
- Note: kucms-02 is running Alma Linux 9
- Installed two Ph2_ACF v5-04 working areas and two types of FC7 FW v4.9 for RD53B electrical and optical readout
- Documented RD53B SCC electrical readout setup instructions in text file (not in readme yet)
- Added new xml file for RD53B SCC electrical readout for Ph2_ACF v5-04: still testing

New working areas on kucms-02:
```
/home/kucms/TrackerDAQ/module_testing_v1/Ph2_ACF
/home/kucms/TrackerDAQ/elink_testing_v1/Ph2_ACF
```
The module_testing_v1 area will be used for module testing (module x-ray testing, etc.), and the elink_testing_v1 area will be used for e-link testing (port card + e-link + RD53B SCC, etc.).